### PR TITLE
fix(Jenkinsfile): CHANGE_BRANCH - not BRANCH_NAME

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 //Library('cdis-jenkins-lib@fix/gitops-qa') _
 
 // See 'Loading libraries dynamically' here: https://jenkins.io/doc/book/pipeline/shared-libraries/
-library identifier: "cdis-jenkins-lib@${env.BRANCH_NAME}"
+library identifier: "cdis-jenkins-lib@${env.CHANGE_BRANCH}"
 
 testPipeline {
   // overrides for testing the ModifyManifest stage ...


### PR DESCRIPTION
Change required after we reconfigured Jenkins to build "pull requests" instead of "branches that have been submit as pull requests" ... :-p