### PR TITLE
chore(qa): GitHub label magic

### DIFF
--- a/vars/githubHelper.groovy
+++ b/vars/githubHelper.groovy
@@ -4,7 +4,7 @@ def fetchLabels() {
     def PR_NUMBER = env.BRANCH_NAME.split('-')[1];
     def REPO_NAME = env.JOB_NAME;
     println('REPO_NAME: ' + REPO_NAME);
-    labels_url="https://api.github.com/repos/uc-cdis/${REPO_NAME}/issues/${PR_NUMBER}/labels"
+    labels_url="https://api.github.com/repos/uc-cdis/gen3-qa/issues/${PR_NUMBER}/labels"
     println("Shooting a request to: " + labels_url);
     def get = new URL(labels_url).openConnection();
     def getRC = get.getResponseCode();

--- a/vars/githubHelper.groovy
+++ b/vars/githubHelper.groovy
@@ -3,6 +3,7 @@ def fetchLabels() {
   try{
     def PR_NUMBER = env.BRANCH_NAME.split('-')[1];
     def REPO_NAME = env.JOB_NAME;
+    println('REPO_NAME: ' + REPO_NAME);
     labels_url="https://api.github.com/repos/uc-cdis/${REPO_NAME}/issues/${PR_NUMBER}/labels"
     println("Shooting a request to: " + labels_url);
     def get = new URL(labels_url).openConnection();

--- a/vars/githubHelper.groovy
+++ b/vars/githubHelper.groovy
@@ -2,9 +2,9 @@ import groovy.json.JsonSlurperClassic
 def fetchLabels() {
   try{
     def PR_NUMBER = env.BRANCH_NAME.split('-')[1];
-    def REPO_NAME = env.JOB_NAME;
+    def REPO_NAME = env.JOB_NAME.split('/')[1];
     println('REPO_NAME: ' + REPO_NAME);
-    labels_url="https://api.github.com/repos/uc-cdis/gen3-qa/issues/${PR_NUMBER}/labels"
+    labels_url="https://api.github.com/repos/uc-cdis/${REPO_NAME}/issues/${PR_NUMBER}/labels"
     println("Shooting a request to: " + labels_url);
     def get = new URL(labels_url).openConnection();
     def getRC = get.getResponseCode();

--- a/vars/githubHelper.groovy
+++ b/vars/githubHelper.groovy
@@ -1,0 +1,23 @@
+import groovy.json.JsonSlurperClassic
+def fetchLabels() {
+  try{
+    def PR_NUMBER = env.BRANCH_NAME.split('-')[1];
+    def REPO_NAME = env.JOB_NAME;
+    labels_url="https://api.github.com/repos/uc-cdis/${REPO_NAME}/issues/${PR_NUMBER}/labels"
+    println("Shooting a request to: " + labels_url);
+    def get = new URL(labels_url).openConnection();
+    def getRC = get.getResponseCode();
+    println(getRC);
+    def jsonSlurper = new groovy.json.JsonSlurperClassic();
+    labels = null;
+    if(getRC.equals(200)) {
+      labelsJson = get.getInputStream().getText();
+      println(labelsJson);
+      labels = jsonSlurper.parseText(labelsJson);
+    }
+    return labels;
+  } catch (e) {
+    pipelineHelper.handleError(e)
+  }
+  return null;
+}

--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -92,10 +92,6 @@ def newKubeLock(String kubectlNamespace, String lockOwner, String lockName) {
 * @param owner - lock owner
 */
 def selectAndLockNamespace(String lockOwner, List<String> namespaces = null) {
-  if (!namespaces) {
-    namespaces = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
-  }
-
   lockName = 'jenkins'
   int randNum = new Random().nextInt(namespaces.size());
 

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -7,7 +7,7 @@
 */
 def call(Map config) {
   node {
-    def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel', 'my-test']
+    def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
     List<String> namespaces = []
     prLabels = null
     kubectlNamespace = null

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -7,12 +7,41 @@
 */
 def call(Map config) {
   node {
+    def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel', 'my-test']
+    List<String> namespaces = []
+    prLabels = null
     kubectlNamespace = null
     kubeLocks = []
     testedEnv = "" // for manifest pipeline
     pipeConfig = pipelineHelper.setupConfig(config)
     pipelineHelper.cancelPreviousRunningBuilds()
+    prLabels = githubHelper.fetchLabels()
     try {
+      stage('CheckPRLabels') {
+        for(label in prLabels) {
+          println(label['name']);
+          switch(label['name']) {
+            case "doc-only":
+              println('TODO: Skip tests')
+              break
+            case "debug":
+              println("Call npm test with --debug")
+              println("leverage CodecepJS feature require('codeceptjs').output.debug feature")
+              break
+            case AVAILABLE_NAMESPACES:
+              println('found this namespace label! ' + label['name']);
+              namespaces.add(label['name'])
+              break
+           default:
+            println('no-effect label')
+            break
+          }
+        }
+        // If none of the jenkins envs. have been selected pick one at random
+        if (namespaces.size == 0) {
+          namespaces = AVAILABLE_NAMESPACES
+        }
+      }
       stage('FetchCode') {
         gitHelper.fetchAllRepos(pipeConfig['currentRepoName'])
       }
@@ -25,7 +54,7 @@ def call(Map config) {
           )
         }
         stage('SelectNamespace') {
-          (kubectlNamespace, lock) = kubeHelper.selectAndLockNamespace(pipeConfig['UID'])
+          (kubectlNamespace, lock) = kubeHelper.selectAndLockNamespace(pipeConfig['UID'], namespaces)
           kubeLocks << lock
         }
         stage('ModifyManifest') {
@@ -40,7 +69,7 @@ def call(Map config) {
       if (pipeConfig.MANIFEST != null && (pipeConfig.MANIFEST == true || pipeConfig.MANIFEST == "True")) {
         // Setup stages for MANIFEST builds
         stage('SelectNamespace') {
-          (kubectlNamespace, lock) = kubeHelper.selectAndLockNamespace(pipeConfig['UID'])
+          (kubectlNamespace, lock) = kubeHelper.selectAndLockNamespace(pipeConfig['UID'], namespaces)
           kubeLocks << lock
         }
         stage('ModifyManifest') {


### PR DESCRIPTION
This change will allow the user to pick which Jenkins environment should be used for the integration tests by applying a Github label on the PR.

This is very useful for troubleshooting and other experiments.
Some Jenkins environments might not be suitable for a given set of tests (for whatever reason) so this should help us achieve more control over our release flow until all the Jenkins environments are in an homogenous state.

@Alessandro / @marcelo https://ctds-planx.atlassian.net/browse/PXP-5155 I made a bug report for one of the issues we ran into yesterday: PRs against cdis-manifest for internalstaging are NOT running the google tests, PRs against Prod are though
I think :this: is pretty critical to get fixed sooner rather than later. We won't catch actual bugs with Google Data Access until Prod PRs

Here's a demo -> I can pick jenkins-genomel in this PR through a Github label: https://github.com/uc-cdis/gen3-qa/pull/220

This will also open many possibilities for different flavors of testing flow, such as:
- Documentation check only
- Debug (increase verboseness of the tests)
- Produce special reports if a given label is applied, e.g., `release`