### PR TITLE
chore(QA): Avoid unnecessary tests while updating documentation

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -55,10 +55,15 @@ def call(Map config) {
       if (pipeConfig.MANIFEST == null || pipeConfig.MANIFEST == false || pipeConfig.MANIFEST != "True") {
         // Setup stages for NON manifest builds
         stage('WaitForQuayBuild') {
-          quayHelper.waitForBuild(
-            pipeConfig['quayRegistry'],
-            pipeConfig['currentBranchFormatted']
-          )
+	  when {
+            expression { isDocumentationOnly == false }
+          }
+	  steps {
+            quayHelper.waitForBuild(
+              pipeConfig['quayRegistry'],
+              pipeConfig['currentBranchFormatted']
+            )
+	  }
         }
         stage('SelectNamespace') {
 	  when {
@@ -101,6 +106,7 @@ def call(Map config) {
 	  steps {
             testedEnv = manifestHelper.manifestDiff(kubectlNamespace)
           }
+	}
       }
 
       stage('K8sReset') {


### PR DESCRIPTION
We are now running the full suite of tests every time we update a markdown file, which is time-consuming and even locks a Jenkins environment that could be used in a real PR check.

That leads people to force merge PRs, which leaves a trail of inconsistent PRs.

To address that, we can use a `doc-only` label in the PRs that are related to documentation updates.

Successful test for reference:
https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS%20GitHub%20Org%2Fgen3-qa/detail/PR-229/6/pipeline/10