### PR TITLE
chore(qa): Improve  behavior for the "doc-only" PR label

### DIFF
--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -1,0 +1,19 @@
+def checkTestSkippingCriteria() {
+  HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
+  for (String key : fileChanges.keySet()) {
+    fileChange = fileChanges[key][0]
+    // println('checking: ' + fileChange)
+    def releasesFolder = fileChange =~ /^(releases\/.*)/
+    def markdownFile = fileChange =~ /(.*\.md)/
+    if (releasesFolder) {
+      println('Found releases folder: ' + releasesFolder[0][0])
+    } else if (markdownFile) {
+      println('Found markdown file: ' + markdownFile[0][0])
+    } else {
+      println('This PR is eligible for testing')
+      return false
+    }
+  }
+  println('doc-only changes, skipping tests...')
+  return true
+}

--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -2,6 +2,9 @@ def checkTestSkippingCriteria() {
   HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
   for (String key : fileChanges.keySet()) {
     fileChange = fileChanges[key][0]
+    if (fileChange == "Jenkinsfile") {
+      continue
+    }
     // println('checking: ' + fileChange)
     def releasesFolder = fileChange =~ /^(releases\/.*)/
     def markdownFile = fileChange =~ /(.*\.md)/

--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -2,7 +2,6 @@ def checkTestSkippingCriteria() {
   HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
   for (String key : fileChanges.keySet()) {
     fileChange = fileChanges[key][0]
-    // println('checking: ' + fileChange)
     def releasesFolder = fileChange =~ /^(releases\/.*)/
     def markdownFile = fileChange =~ /(.*\.md)/
     if (releasesFolder) {

--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -2,9 +2,6 @@ def checkTestSkippingCriteria() {
   HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
   for (String key : fileChanges.keySet()) {
     fileChange = fileChanges[key][0]
-    if (fileChange == "Jenkinsfile") {
-      continue
-    }
     // println('checking: ' + fileChange)
     def releasesFolder = fileChange =~ /^(releases\/.*)/
     def markdownFile = fileChange =~ /(.*\.md)/

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -31,7 +31,7 @@ def call(Map config) {
             case "doc-only":
               println('Skip tests if git diff matches expected criteria')
 	      isDocumentationOnly = docOnlyHelper.checkTestSkippingCriteria()
-	      break
+              break
             case "gen3-release":
               println('Enable additional tests and automation')
               isGen3Release = "true"

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -31,6 +31,7 @@ def call(Map config) {
             case "doc-only":
               println('Skip tests if git diff matches expected criteria')
 	      isDocumentationOnly = docOnlyHelper.checkTestSkippingCriteria()
+	      break
             case "gen3-release":
               println('Enable additional tests and automation')
               isGen3Release = "true"

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -30,13 +30,7 @@ def call(Map config) {
           switch(label['name']) {
             case "doc-only":
               println('Skip tests if git diff matches expected criteria')
-	      HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
-              for (String key : fileChanges.keySet())
-              {
-	        println('modified file: ' + fileChanges[key])
-	      }
-	      isDocumentationOnly = true
-              break
+	      isDocumentationOnly = docOnlyHelper.checkTestSkippingCriteria()
             case "gen3-release":
               println('Enable additional tests and automation')
               isGen3Release = "true"

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -21,6 +21,9 @@ def call(Map config) {
     pipelineHelper.cancelPreviousRunningBuilds()
     prLabels = githubHelper.fetchLabels()
     try {
+      stage('FetchCode') {
+        gitHelper.fetchAllRepos(pipeConfig['currentRepoName'])
+      }
       stage('CheckPRLabels') {
         for(label in prLabels) {
           println(label['name']);
@@ -55,14 +58,7 @@ def call(Map config) {
         if (namespaces.size == 0) {
           namespaces = AVAILABLE_NAMESPACES
         }
-      }
-      stage('FetchCode') {
-        if(!isDocumentationOnly) {
-          gitHelper.fetchAllRepos(pipeConfig['currentRepoName'])
-	} else {
-	  Utils.markStageSkippedForConditional(STAGE_NAME)
-	}
-      }
+      }      
       if (pipeConfig.MANIFEST == null || pipeConfig.MANIFEST == false || pipeConfig.MANIFEST != "True") {
         // Setup stages for NON manifest builds
         stage('WaitForQuayBuild') {

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -26,7 +26,12 @@ def call(Map config) {
           println(label['name']);
           switch(label['name']) {
             case "doc-only":
-              println('TODO: Skip tests')
+              println('Skip tests if git diff matches expected criteria')
+	      HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
+              for (String key : fileChanges.keySet())
+              {
+	        println('modified file: ' + key)
+	      }
 	      isDocumentationOnly = true
               break
             case "gen3-release":

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -33,7 +33,7 @@ def call(Map config) {
 	      HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
               for (String key : fileChanges.keySet())
               {
-	        println('modified file: ' + key)
+	        println('modified file: ' + fileChanges[key])
 	      }
 	      isDocumentationOnly = true
               break


### PR DESCRIPTION
To avoid some irresponsible usage of the `doc-only` PR label, this logic will make sure that the list of modified files in the PR is solely comprised of:
- Markdown files (ending with the `.md` extension)
- Files under a `releases` folder that sits in the root directory of the repo (this is needed so we can document the Gen3 Core Release artifacts -- A better approach can be considered later).

Successfully tested here:
https://github.com/uc-cdis/gen3-qa/pull/245