### PR TITLE
chore(qa): Skip tests for githooks

### DIFF
--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -3,14 +3,11 @@ def checkTestSkippingCriteria() {
   for (String key : fileChanges.keySet()) {
     fileChange = fileChanges[key][0]
     def releasesFolder = fileChange =~ /^(releases\/.*)/
-    def gitHookScript = fileChange =~ /^(.githooks\/.*)/
     def textFile = fileChange =~ /(.*\.md)|(.*\.txt)|(.*\.feature)/
     if (releasesFolder) {
       println('Found releases folder: ' + releasesFolder[0][0])
     } else if (textFile) {
       println('Found text file: ' + textFile[0][0])
-    } else if (githook) {
-      println('Found githook script: ' + gitHookScript[0][0])
     } else {
       println('This PR is eligible for testing')
       return false

--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -3,11 +3,14 @@ def checkTestSkippingCriteria() {
   for (String key : fileChanges.keySet()) {
     fileChange = fileChanges[key][0]
     def releasesFolder = fileChange =~ /^(releases\/.*)/
+    def gitHookScript = fileChange =~ /^(.githooks\/.*)/
     def textFile = fileChange =~ /(.*\.md)|(.*\.txt)|(.*\.feature)/
     if (releasesFolder) {
       println('Found releases folder: ' + releasesFolder[0][0])
     } else if (textFile) {
       println('Found text file: ' + textFile[0][0])
+    } else if (githook) {
+      println('Found githook script: ' + gitHookScript[0][0])
     } else {
       println('This PR is eligible for testing')
       return false

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -80,7 +80,7 @@ def manifestDiff(String selectedNamespace) {
     HashMap fileChanges = gitHelper.getLatestChangeOfBranch('HEAD')
     for (String key : fileChanges.keySet())
     {
-      if (key != '.')
+      if (key != '.' && key != '.githooks')
       {
         String rs = mergeManifest(key, selectedNamespace)
         echo "new manifest $rs"


### PR DESCRIPTION
While trying to introduce a githook script to the `cdis-manifest` repo,  the groovy pipeline tries to find a `manifest.json` inside the `.githooks` folder 🤦‍♂ . This is a quick measure to avoid that.