### PR TITLE
chore(qa): Skip tests if the PR contains only md and images

### DIFF
--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -3,11 +3,11 @@ def checkTestSkippingCriteria() {
   for (String key : fileChanges.keySet()) {
     fileChange = fileChanges[key][0]
     def releasesFolder = fileChange =~ /^(releases\/.*)/
-    def textFile = fileChange =~ /(.*\.md)|(.*\.txt)|(.*\.feature)/
+    def docFile = fileChange =~ /(.*\.md)|(.*\.png)|(.*\.txt)|(.*\.feature)/
     if (releasesFolder) {
       println('Found releases folder: ' + releasesFolder[0][0])
-    } else if (textFile) {
-      println('Found text file: ' + textFile[0][0])
+    } else if (docFile) {
+      println('Found text file: ' + docFile[0][0])
     } else {
       println('This PR is eligible for testing')
       return false


### PR DESCRIPTION
There is no need to run tests if the PR only contains markdown files and images.