### PR TITLE
chore(qa): Set testedEnv as arg to health check script

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -128,7 +128,7 @@ def call(Map config) {
       stage('VerifyClusterHealth') {
         if(!isDocumentationOnly) {
           kubeHelper.waitForPods(kubectlNamespace)
-          testHelper.checkPodHealth(kubectlNamespace)
+          testHelper.checkPodHealth(kubectlNamespace, testedEnv)
         } else {
           Utils.markStageSkippedForConditional(STAGE_NAME)
         }

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -132,10 +132,10 @@ def cleanS3() {
 /**
 * Verify pods are health
 */
-def checkPodHealth(String namespace) {
+def checkPodHealth(String namespace, String testedEnv) {
   dir('gen3-qa') {
     gen3Qa(namespace, {
-      sh "bash ./check-pod-health.sh"
+      sh "bash ./check-pod-health.sh $testedEnv"
     })
   }
 }


### PR DESCRIPTION
Need to run specific health checks based on the value of the testedEnv variable, the groovy pipeline logic needs to pass this variable to the `check-pod-health.sh` bash script from `gen3-qa`.