### PR TITLE
fix random namespace selection

### DIFF
--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -100,8 +100,8 @@ def selectAndLockNamespace(String lockOwner, List<String> namespaces = null) {
   while(times != 120) {
     // try to find an unlocked namespace
     for (int i=0; i < namespaces.size(); ++i) {
-      randNum = (randNum + i) % namespaces.size();
-      kubectlNamespace = namespaces.get(randNum)
+      namespaceIndex = (randNum + i) % namespaces.size();
+      kubectlNamespace = namespaces.get(namespaceIndex)
       println("attempting to lock namespace ${kubectlNamespace} with a wait time of 1 minutes")
       if (klock('lock', lockOwner, lockName, kubectlNamespace)) {
         echo("namespace ${kubectlNamespace}")


### PR DESCRIPTION
we want to pick a random index in `namespaces` (size 5), let's say 2, and then check all the namespaces in order: 2, 3, 4, 0, 1 (initial index + 0, initial index + 1, initial index + 2...)
that doesn't work if we overwrite the initial index

```
int randNum = new Random().nextInt(namespaces.size());
for (int i=0; i < namespaces.size(); ++i) {
    randNum = (randNum + i) % namespaces.size();
    ...
```

### Bug Fixes
- Try to lock each namespace