### PR TITLE
Revert "chore(qa): Do not modify manifests when introducing a new CI environment"

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -12,7 +12,6 @@ def call(Map config) {
     def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
     List<String> namespaces = []
     doNotRunTests = false
-    doNotModifyManifest = false
     isGen3Release = "false"
     selectedTest = "all"
     prLabels = null
@@ -46,9 +45,6 @@ def call(Map config) {
             case "decommission-environment":
               println('Skip tests if an environment folder is deleted')
               doNotRunTests = decommissionEnvHelper.checkDecommissioningEnvironment()
-            case "commission-environment":
-              println('Skip ModifyManifest step to introduce a new CI environment')
-              doNotModifyManifest = true 
             case "gen3-release":
               println('Enable additional tests and automation')
               isGen3Release = "true"
@@ -96,7 +92,7 @@ def call(Map config) {
           }
         }
         stage('ModifyManifest') {
-          if(!doNotRunTests && !doNotModifyManifest) {
+          if(!doNotRunTests) {
             manifestHelper.editService(
               kubeHelper.getHostname(kubectlNamespace),
               pipeConfig.serviceTesting.name,


### PR DESCRIPTION
This is no longer necessary.
As per: https://github.com/uc-cdis/gitops-qa/pull/519

Reverts uc-cdis/cdis-jenkins-lib#84