### PR TITLE
chore(qa): Skip tests for changes in dot folders

### DIFF
--- a/vars/docOnlyHelper.groovy
+++ b/vars/docOnlyHelper.groovy
@@ -4,11 +4,14 @@ def checkTestSkippingCriteria() {
     fileChange = fileChanges[key][0]
     def releasesFolder = fileChange =~ /^(releases\/.*)/
     def openapisFolder = fileChange =~ /^(openapis\/.*\.yaml)/
+    def dotFolder = fileChange =~ /^(\..*)/
     def docFile = fileChange =~ /(.*\.md)|(.*\.png)|(.*\.txt)|(.*\.feature)/
     if (releasesFolder) {
       println('Found releases folder: ' + releasesFolder[0][0])
     } else if (openapisFolder) {
       println('Found yaml file: ' + openapisFolder[0][0])
+    } else if (dotFolder) {
+      println('Found changes in a file inside dot folder: ' + dotFolder[0][0])
     } else if (docFile) {
       println('Found text file: ' + docFile[0][0])
     } else {


### PR DESCRIPTION
This should augment the `doc-only` PR label logic to ignore changes in files that live inside dot folders.

Required to deliver this:
https://github.com/uc-cdis/cdis-manifest/pull/1535/files

Tested in `/script`:
![image](https://user-images.githubusercontent.com/2052006/81750678-9cbcf300-9473-11ea-9db3-ba3578d0fb6f.png)
