### PR TITLE
chore(qa): Delete gcp svc acct keys before running tests to avoid intermittent failures in google tests

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -95,6 +95,13 @@ def call(Map config) {
 	    Utils.markStageSkippedForConditional(STAGE_NAME)
           }
         }
+        stage('CleanUp3rdPartyResources') {
+          if(!doNotRunTests) {
+            testHelper.deleteGCPServiceAccountKeys(kubectlNamespace)
+	  } else {
+	    Utils.markStageSkippedForConditional(STAGE_NAME)
+          }
+        }
         stage('ModifyManifest') {
           if(!doNotRunTests && !doNotModifyManifest) {
             manifestHelper.editService(

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -98,8 +98,8 @@ def call(Map config) {
         stage('CleanUp3rdPartyResources') {
           if(!doNotRunTests) {
             testHelper.deleteGCPServiceAccountKeys(kubectlNamespace)
-	  } else {
-	    Utils.markStageSkippedForConditional(STAGE_NAME)
+          } else {
+            Utils.markStageSkippedForConditional(STAGE_NAME)
           }
         }
         stage('ModifyManifest') {

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -173,7 +173,7 @@ def deleteGCPServiceAccountKeys(jenkinsNamespace) {
     for(String sa: svc_accounts) {
       sa = sa.replace("JPREFIX", JPREFIX)
       println("deleting keys for ${sa}...");
-      def sa_keys = sh(script: "gcloud iam service-accounts keys list --iam-account $sa", returnStdout: true)
+      def sa_keys = sh(script: "gcloud iam service-accounts keys list --iam-account $sa || exit 0", returnStdout: true)
 
       key_rows = sa_keys.split("\n");
       for (int i = 0; i < key_rows.length; i++) {

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -165,7 +165,9 @@ def deleteGCPServiceAccountKeys(jenkinsNamespace) {
       break;
     default:
       println("invalid jenkins namespace: " + SELECTED_JENKINS_NAMESPACE);
-      break;
+      // If the CI environment is not listed here
+      // it is probably not configured for google integration tests
+      return 0;
     }
 
     def svc_accounts = ['JPREFIX-cdisautotestgmailcom-6@dcf-integration.iam.gserviceaccount.com', 'JPREFIX-cdisautotestgmailcom-7@dcf-integration.iam.gserviceaccount.com', 'JPREFIX-cdisautotestgmailcom-8@dcf-integration.iam.gserviceaccount.com']

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -136,7 +136,7 @@ def cleanS3() {
 def deleteGCPServiceAccountKeys(jenkinsNamespace) {
   withCredentials([file(credentialsId: 'fence-google-app-creds-secret', variable: 'MY_SECRET_GCLOUD_APP_CREDENTIALS_FILE')]) {
     sh '''
-      cat $MY_SECRET_GCLOUD_APP_CREDENTIALS_FILE > fence_google_app_creds_secret.json
+      mv $MY_SECRET_GCLOUD_APP_CREDENTIALS_FILE fence_google_app_creds_secret.json
       gcloud auth activate-service-account --key-file fence_google_app_creds_secret.json
 
 

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -179,7 +179,7 @@ def deleteGCPServiceAccountKeys(jenkinsNamespace) {
 
       key_rows = sa_keys.split("\n");
       for (int i = 0; i < key_rows.length; i++) {
-        // Skipe headers
+        // Skip headers
         if (i == 0) continue
         println("key row: " + key_rows[i])
         def key_id = key_rows[i].split(" ")[0]


### PR DESCRIPTION
Tested in: https://github.com/uc-cdis/gen3-qa/pull/334
by overriding the Jenkins lib in the `Jenkinsfile`:
```
@Library('cdis-jenkins-lib@chore/delete_gcp_svc_acct_keys_before_running_tests') _
```

This should prevent intermittent failures related to google tests.