### PR TITLE
chore(qa): Don't merge existing sower jobs defined for Jenkins CI envs

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -41,11 +41,11 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     }
   }
   if (dels != "") {
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && echo \$old | jq '.sower = []' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && echo \$old | jq -r '.sower = []' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
-          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --arg sj ${sj} --argjson vs \"\$bs\"""" 
+          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj ${sj} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -45,7 +45,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
-          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj ${sj} --argjson vs \"\$bs\"""" 
+          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj \"\$sj\" --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -47,7 +47,9 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
-  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"${sj}\" '(.sower) |= . + \$sj\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
+          + """&& echo \$old | jq -r --argjson sj \"${sj}\" """
+          + "'(.sower) |=/ . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -26,7 +26,7 @@ def editService(String commonsHostname, String serviceName, String quayBranchNam
 def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
-  String sj = sh(returnStdout: true, script: "jq .sower < tmpGitClone/$changedDir/manifest.json").trim()
+  String sj = sh(returnStdout: true, script: "jq -r .sower < tmpGitClone/$changedDir/manifest.json").trim()
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -27,7 +27,6 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
   String sj = sh(returnStdout: true, script: "jq .sower < tmpGitClone/$changedDir/manifest.json").trim()
-  println(sj);
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)
@@ -47,7 +46,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj ${sj} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
-          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + . "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -46,7 +46,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
-          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" '/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -48,8 +48,8 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
-          + """&& echo \$old | jq -r --argjson sj \"${sj}\" """
-          + "'(.sower) |=/ . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+          + """&& echo \$old | jq -r --argjson sj ${sj} """
+          + "'(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -26,7 +26,7 @@ def editService(String commonsHostname, String serviceName, String quayBranchNam
 def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
-  String sj = sh(returnStdout: true, script: "jq -r .sower < tmpGitClone/$changedDir/manifest.json").trim()
+  String sj = sh(returnStdout: true, script: "jq .sower < tmpGitClone/$changedDir/manifest.json").trim()
   println(sj);
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
@@ -45,7 +45,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
-          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj \"\$sj\" --argjson vs \"\$bs\"""" 
+          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj ${sj} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -47,7 +47,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
-  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && jq -r --argjson sj \"${sj}\" '(.sower) |= . + $sj\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"${sj}\" '(.sower) |= . + \$sj\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -39,7 +39,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     }
   }
   if (dels != "") {
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && jq '.sower = []' cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && echo \$old | jq '.sower = []' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -41,7 +41,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     }
   }
   if (dels != "") {
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && echo \$old | jq -r '.sower = []' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && echo \$old | jq '.sower = []' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -39,7 +39,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     }
   }
   if (dels != "") {
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && jq \'.sower = []\' cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && jq '.sower = []' cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -44,7 +44,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
-          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
+          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --arg sj ${sj} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -47,7 +47,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
-  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && jq -r --argjson sj \"${sj}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && jq -r --argjson sj \"${sj}\" '(.sower) |= . + $sj\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -26,7 +26,8 @@ def editService(String commonsHostname, String serviceName, String quayBranchNam
 def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
-  String sj = sh(returnStdout: true, script: "jq -r .sower < tmpGitClone/$changedDir/manifest.json").trim()
+  // fetch sower block from the target environment
+  sh 'jq -r .sower < tmpGitClone/$changedDir/manifest.json > sower_block.json'
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)
@@ -47,7 +48,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
-  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj ${sj} '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -27,6 +27,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
   String sj = sh(returnStdout: true, script: "jq -r .sower < tmpGitClone/$changedDir/manifest.json").trim()
+  println(sj);
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -46,7 +46,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj ${sj} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
-          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ . + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + ". + \$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -44,9 +44,10 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
-          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj ${sj} --argjson vs \"\$bs\"""" 
+          + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
-          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + ". + \$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+          + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && jq -r --argjson sj \"${sj}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -46,7 +46,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson sj ${sj} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
-          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + . "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ . + "\$sj" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -26,6 +26,7 @@ def editService(String commonsHostname, String serviceName, String quayBranchNam
 def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
+  String sj = sh(returnStdout: true, script: "jq -r .sower < tmpGitClone/$changedDir/manifest.json").trim()
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)
@@ -45,7 +46,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
-          + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+          + / | (.versions) |=/ + "\$vs" + / | (.sower) |=/ + "\$sj" '/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -39,7 +39,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     }
   }
   if (dels != "") {
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r \'${dels}\' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json && jq \'.sower = []\' cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   sh(returnStdout: true, script: "bs=\$(jq -r .versions < tmpGitClone/$changedDir/manifest.json) "
           + "&& old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -27,7 +27,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
   // fetch sower block from the target environment
-  sh 'jq -r .sower < tmpGitClone/$changedDir/manifest.json > sower_block.json'
+  sh "jq -r .sower < tmpGitClone/$changedDir/manifest.json > sower_block.json"
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -47,9 +47,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
-  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) "
-          + """&& echo \$old | jq -r --argjson sj ${sj} """
-          + "'(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj ${sj} '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }


### PR DESCRIPTION
Currently, the manifest indexing sower jobs that are defined across all the Jenkins CI environments (https://github.com/uc-cdis/gitops-qa/blob/master/jenkins-blood.planx-pla.net/manifest.json#L45) are being merged with the `manifest.json` from various environments from `cdis-manifest` that do not have such jobs enabled, which is erroneously triggering the @indexing / Indexing GUI test suite.

This change will empty the `sower` block from the Jenkins CI environments' `manifest.json` before environment-specific sower jobs can be added to the config.