### PR TITLE
chore(qa): Set jenkins service account for sower jobs

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -49,15 +49,10 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
-  println(sowerBlock)
   if (sowerBlock != "null") {
     // set Jenkins CI service accounts for sower jobs if the property exists
     sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | tee sower_block.json")
-    String sowerBlock2 = sh(returnStdout: true, script: "cat sower_block.json")
-    println(sowerBlock2)
     sh(returnStdout: true, script: "cat sower_block.json | jq -s . | tee sower_block.json")
-    String sowerBlock3 = sh(returnStdout: true, script: "cat sower_block.json")
-    println(sowerBlock3)
    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -52,7 +52,8 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   if (sowerBlock != "null") {
     // set Jenkins CI service accounts for sower jobs if the property exists
     sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > sower_block.json")
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+   sh(returnStdout: true, script: "cat sower_block.json")
+   sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -52,9 +52,12 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   println(sowerBlock)
   if (sowerBlock != "null") {
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | jq -s '.' | tee sower_block.json")
+    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | tee sower_block.json")
     String sowerBlock2 = sh(returnStdout: true, script: "cat sower_block.json")
     println(sowerBlock2)
+    sh(returnStdout: true, script: "cat sower_block.json | jq -s . | tee sower_block.json")
+    String sowerBlock3 = sh(returnStdout: true, script: "cat sower_block.json")
+    println(sowerBlock3)
    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -52,7 +52,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   println(sowerBlock)
   if (sowerBlock != "null") {
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | tee sower_block.json")
+    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | jq -s '.' | tee sower_block.json")
     String sowerBlock2 = sh(returnStdout: true, script: "cat sower_block.json")
     println(sowerBlock2)
    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -49,9 +49,12 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
+  println(sowerBlock)
   if (sowerBlock != "null") {
     // set Jenkins CI service accounts for sower jobs if the property exists
     sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | tee sower_block.json")
+    String sowerBlock2 = sh(returnStdout: true, script: "cat sower_block.json")
+    println(sowerBlock2)
    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -51,8 +51,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
   if (sowerBlock != "null") {
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > sower_block.json")
-   sh(returnStdout: true, script: "cat sower_block.json")
+    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | tee sower_block.json")
    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -53,7 +53,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   if (sowerBlock != "null") {
     sh(returnStdout: true, script: "echo ${old} | jq -r --argjson sj \"${sowerBlock}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "echo ${old} | jq -r '.sower[] | if has("serviceAccountName") then .serviceAccountName = "jobs-${selectedNamespace}-planx-pla-net" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "echo ${old} | jq -r '.sower[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -50,9 +50,9 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
   if (sowerBlock != "null") {
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r '.sower[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > sower_block.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -49,11 +49,10 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
-  def old = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   if (sowerBlock != "null") {
-    sh(returnStdout: true, script: "echo \"${old}\" | jq -r --argjson sj \"${sowerBlock}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"${sowerBlock}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "echo \"${old}\" | jq -r '.sower[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r '.sower[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -50,7 +50,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
   if (sowerBlock != "null") {
-    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"${sowerBlock}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
     // set Jenkins CI service accounts for sower jobs if the property exists
     sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r '.sower[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -48,7 +48,13 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
-  sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
+  def old = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  if (sowerBlock != "null") {
+    sh(returnStdout: true, script: "echo ${old} | jq -r --argjson sj \"${sowerBlock}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    // set Jenkins CI service accounts for sower jobs if the property exists
+    sh(returnStdout: true, script: "echo ${old} | jq -r '.sower[] | if has("serviceAccountName") then .serviceAccountName = "jobs-${selectedNamespace}-planx-pla-net" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+  }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -51,9 +51,9 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   String sowerBlock = sh(returnStdout: true, script: "cat sower_block.json")
   def old = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   if (sowerBlock != "null") {
-    sh(returnStdout: true, script: "echo ${old} | jq -r --argjson sj \"${sowerBlock}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "echo \"${old}\" | jq -r --argjson sj \"${sowerBlock}\" '(.sower) |= . + \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "echo ${old} | jq -r '.sower[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
+    sh(returnStdout: true, script: "echo \"${old}\" | jq -r '.sower[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs


### PR DESCRIPTION
The sower blocks need to be mutated with the proper k8s service account that corresponds to the selected Jenkins namespace.