### PR TITLE
chore(qa): PR Checks must run on the master jenkins container only

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -8,7 +8,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 * @param config - pipeline configuration
 */
 def call(Map config) {
-  node {
+  node('master') {
     def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
     List<String> namespaces = []
     doNotRunTests = false


### PR DESCRIPTION
Due to the introduction of the new Jenkins worker (`gen3-qa-worker`), Jenkins is randomly assigning PR checks to the new worker. But the worker image doesn't have all the required dependencies to run PR checks (e.g., python3.6, jq and other CLI utilities).

We need to make sure that pipeline jobs will run only on the Jenkins `master` node.
