### PR TITLE
Chore/delete gcp svc accts before google tests

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -93,7 +93,7 @@ def call(Map config) {
         }
         stage('CleanUp3rdPartyResources') {
           if(!doNotRunTests) {
-            testHelper.deleteGCPServiceAccountKeys(kubectlNamespace)
+            testHelper.deleteGCPServiceAccounts(kubectlNamespace)
           } else {
             Utils.markStageSkippedForConditional(STAGE_NAME)
           }
@@ -123,7 +123,7 @@ def call(Map config) {
         }
         stage('CleanUp3rdPartyResources') {
           if(!doNotRunTests) {
-            testHelper.deleteGCPServiceAccountKeys(kubectlNamespace)
+            testHelper.deleteGCPServiceAccounts(kubectlNamespace)
           } else {
             Utils.markStageSkippedForConditional(STAGE_NAME)
           }

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -145,23 +145,23 @@ def deleteGCPServiceAccounts(jenkinsNamespace) {
 
     switch(SELECTED_JENKINS_NAMESPACE) {
     case "jenkins-dcp":
-      println("deleting jdcp keys");
+      println("deleting jdcp svc accounts");
       JPREFIX="jdcp"
       break;
     case "jenkins-brain":
-      println("deleting jbrain keys");
+      println("deleting jbrain svc accounts");
       JPREFIX="jbrain"
       break;
     case "jenkins-blood":
-      println("deleting jblood keys");
+      println("deleting jblood svc accounts");
       JPREFIX="jblood"
       break;
     case "jenkins-genomel":
-      println("deleting jgmel keys");
+      println("deleting jgmel svc accounts");
       JPREFIX="jgmel"
       break;
     case "jenkins-niaid":
-      println("deleting jniaid keys");
+      println("deleting jniaid svc accounts");
       JPREFIX="jniaid"
       break;
     default:
@@ -182,7 +182,7 @@ def deleteGCPServiceAccounts(jenkinsNamespace) {
       // Skip header
       if (i == 0) continue
       def sa = svc_accounts[i];
-      println("deleting keys for svc account: " + sa);
+      println("deleting svc account: " + sa);
 
       def sa_deletion_result = sh(script: "gcloud iam service-accounts delete $sa  --quiet || exit 0", returnStdout: true);
       println "sa_deletion_result: ${sa_deletion_result}";

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -131,10 +131,10 @@ def cleanS3() {
 }
 
 /**
-* Delete Service Account keys from the dcf-integration Google Cloud Platform project
-* Lingering keys are causing intermittent failures in the CI tests
+* Delete Service Accounts from the dcf-integration Google Cloud Platform project
+* This should avoid intermittent failures in the CI tests
 */
-def deleteGCPServiceAccountKeys(jenkinsNamespace) {
+def deleteGCPServiceAccounts(jenkinsNamespace) {
   withCredentials([file(credentialsId: 'fence-google-app-creds-secret', variable: 'MY_SECRET_GCLOUD_APP_CREDENTIALS_FILE')]) {
     sh '''
       mv $MY_SECRET_GCLOUD_APP_CREDENTIALS_FILE fence_google_app_creds_secret.json
@@ -184,20 +184,10 @@ def deleteGCPServiceAccountKeys(jenkinsNamespace) {
       def sa = svc_accounts[i];
       println("deleting keys for svc account: " + sa);
 
-      def sa_keys = sh(script: "gcloud iam service-accounts keys list --iam-account $sa --managed-by user || exit 0", returnStdout: true);
-      println "sa_keys: ${sa_keys}";
-
-      key_rows = sa_keys.split("\n");
-      for (int j = 0; j < key_rows.length; j++) {
-        // Skip headers
-        if (j == 0) continue
-        // println("key row: " + key_rows[j])
-        def key_id = key_rows[j].split(" ")[0]
-        def deletion_result = sh(script: "gcloud iam service-accounts keys delete $key_id --iam-account $sa --quiet", returnStatus:true)
-        println(deletion_result)
-      }
+      def sa_deletion_result = sh(script: "gcloud iam service-accounts delete $sa  --quiet || exit 0", returnStdout: true);
+      println "sa_deletion_result: ${sa_deletion_result}";
     }
-    println("The GCP keys correspondent to this jenkins namespace have been deleted.");
+    println("The Service Accounts correspondent to this jenkins namespace have been deleted.");
   }
 }
 


### PR DESCRIPTION
Jira Ticket: [PXP-6111](https://ctds-planx.atlassian.net/browse/PXP-6111)
Deleting google cloud service accounts to try to achieve a _clean slate_ state and mitigate the intermittent failures across Google Data Access tests.

See the code in action here: https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS%20GitHub%20Org%2Fgen3-qa/detail/PR-389/7/pipeline/89

### Improvements
Improve 3rd party clean-up logic to delete GCP service accounts.