### PR TITLE
fix: looking into past 1 hour of builds (as the steps before WaitForQ…

### DIFF
--- a/vars/quayHelper.groovy
+++ b/vars/quayHelper.groovy
@@ -3,7 +3,7 @@
 */
 def waitForBuild(String repoName, String formattedBranch) {
   echo("Waiting for Quay to build:\n  repoName: ${repoName}\n  branch: '${formattedBranch}'\n  commit: ${env.GIT_COMMIT}\n  previous commit: ${env.GIT_PREVIOUS_COMMIT}")
-  def timestamp = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) - 60)
+  def timestamp = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) - 3600)
   def timeout = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) + 3600)
   QUAY_API = 'https://quay.io/api/v1/repository/cdis/'
   timeUrl = "$QUAY_API"+repoName+"/build/?since="+timestamp
@@ -78,7 +78,6 @@ def waitForBuild(String repoName, String formattedBranch) {
             } else if(env.GIT_PREVIOUS_COMMIT && env.GIT_PREVIOUS_COMMIT.startsWith(fields[1])) {
               // previous commit is the newest - sleep and try again
               // things get annoying when quay gets slow
-              noPendingQuayBuilds = false
               break
             } else {
               // if previous commit is the newest one in quay, then maybe


### PR DESCRIPTION
…uayBuild) can take a long time

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
* There are multiple steps before `WaitForQuayBuild`, so it should check longer, past time period on builds.
* Remove the wrong assignment on `noPendingQuayBuilds`

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
