### PR TITLE
fix(qa): Pull v2 CI envs when running PRs on v2 repos

### DIFF
--- a/vars/gitHelper.groovy
+++ b/vars/gitHelper.groovy
@@ -42,10 +42,17 @@ def fetchAllRepos(String currentRepoName) {
     }
   }
   dir('cdis-manifest') {
-    git(
-      url: 'https://github.com/uc-cdis/gitops-qa.git',
-      branch: 'master'
-    )
+    if (currentRepoName.endsWith("v2")) {
+      git(
+        url: 'https://github.com/uc-cdis/gitops-qa-v2.git',
+        branch: 'master'
+      )
+    } else {
+      git(
+        url: 'https://github.com/uc-cdis/gitops-qa.git',
+        branch: 'master'
+      )
+    }
   }
   dir('cloud-automation') {
     if (currentRepoName == "cloud-automation") {


### PR DESCRIPTION
Pull `gitops-qa-v2` source code when running PR checks for `v2` repos.