### PR TITLE
chore(qa): Add new label not-ready-for-ci

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -21,11 +21,6 @@ def call(Map config) {
     pipeConfig = pipelineHelper.setupConfig(config)
     pipelineHelper.cancelPreviousRunningBuilds()
     prLabels = githubHelper.fetchLabels()
-    isDraft = githubHelper.isDraft()
-    if (isDraft == true) {
-      currentBuild.result = 'ABORTED'
-      error('This PR is a draft, abort the CI run...')
-    }
 
     try {
       stage('CleanWorkspace') {
@@ -61,6 +56,10 @@ def call(Map config) {
             case "debug":
               println("Call npm test with --debug")
               println("leverage CodecepJS feature require('codeceptjs').output.debug feature")
+              break
+            case "not-ready-for-ci":
+              currentBuild.result = 'ABORTED'
+              error('This PR is not ready for CI yet, aborting...')
               break
             case AVAILABLE_NAMESPACES:
               println('found this namespace label! ' + label['name']);


### PR DESCRIPTION
Removing change that aborts tests if a PR is marked as a draft.
Also introducing a new label that cancels the execution of CI tests, to be applied if Devs feel their PR is not ready for a full pipeline run.