### PR TITLE
chore(qa): Introduce RAS Test credentials for CI tests

### DIFF
--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -35,10 +35,10 @@ def gen3Qa(String namespace, Closure body, List<String> add_env_variables = []) 
 * @param testedEnv - environment the test is being run for (for manifest PRs)
 */
 def runIntegrationTests(String namespace, String service, String testedEnv, String isGen3Release,  List<String> selectedTests = ['all']) {
-  withCredentials(
-    [usernamePassword(credentialsId: 'ras-test-user1-for-ci-tests', usernameVariable: 'RAS_TEST_USER_1_USERNAME', passwordVariable: 'RAS_TEST_USER_1_PASSWORD')],
-    [usernamePassword(credentialsId: 'ras-test-user2-for-ci-tests', usernameVariable: 'RAS_TEST_USER_2_USERNAME', passwordVariable: 'RAS_TEST_USER_2_PASSWORD')]
-  ) {
+  withCredentials([
+    usernamePassword(credentialsId: 'ras-test-user1-for-ci-tests', usernameVariable: 'RAS_TEST_USER_1_USERNAME', passwordVariable: 'RAS_TEST_USER_1_PASSWORD'),
+    usernamePassword(credentialsId: 'ras-test-user2-for-ci-tests', usernameVariable: 'RAS_TEST_USER_2_USERNAME', passwordVariable: 'RAS_TEST_USER_2_PASSWORD')
+  ]) {
     dir('gen3-qa') {
       gen3Qa(namespace, {
         // clean up old test artifacts in the workspace

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -36,8 +36,8 @@ def gen3Qa(String namespace, Closure body, List<String> add_env_variables = []) 
 */
 def runIntegrationTests(String namespace, String service, String testedEnv, String isGen3Release,  List<String> selectedTests = ['all']) {
   withCredentials(
-    [[$class: 'UsernamePasswordMultiBinding', credentialsId: 'ras-test-user1-for-ci-tests', usernameVariable: 'RAS_TEST_USER_1_USERNAME', passwordVariable: 'RAS_TEST_USER_1_PASSWORD']],
-    [[$class: 'UsernamePasswordMultiBinding', credentialsId: 'ras-test-user2-for-ci-tests', usernameVariable: 'RAS_TEST_USER_2_USERNAME', passwordVariable: 'RAS_TEST_USER_2_PASSWORD']]
+    [usernamePassword(credentialsId: 'ras-test-user1-for-ci-tests', usernameVariable: 'RAS_TEST_USER_1_USERNAME', passwordVariable: 'RAS_TEST_USER_1_PASSWORD')],
+    [usernamePassword(credentialsId: 'ras-test-user2-for-ci-tests', usernameVariable: 'RAS_TEST_USER_2_USERNAME', passwordVariable: 'RAS_TEST_USER_2_PASSWORD')]
   ) {
     dir('gen3-qa') {
       gen3Qa(namespace, {

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -35,44 +35,49 @@ def gen3Qa(String namespace, Closure body, List<String> add_env_variables = []) 
 * @param testedEnv - environment the test is being run for (for manifest PRs)
 */
 def runIntegrationTests(String namespace, String service, String testedEnv, String isGen3Release,  List<String> selectedTests = ['all']) {
-  dir('gen3-qa') {
-    gen3Qa(namespace, {
-      // clean up old test artifacts in the workspace
-      sh "/bin/rm -rf output/ || true"
-      sh "mkdir output"
-      testResult = null
-      List<String> failedTestSuites = [];
-      selectedTests.each {selectedTest ->
-        testResult = sh(script: "bash ./run-tests.sh ${namespace} --service=${service} --testedEnv=${testedEnv} --isGen3Release=${isGen3Release} --selectedTest=${selectedTest}", returnStatus: true);
-      }
-      // check XMLs inside the output folder
-      failedTestSuites = xmlHelper.identifyFailedTestSuites()
-      def featureLabelMap = xmlHelper.assembleFeatureLabelMap(failedTestSuites)
-
-      if (testResult == 0) {
-        // if the test succeeds, then verify that we got some test results ...
-        testResult = sh(script: "ls output/ | grep '.*\\.xml'", returnStatus: true)
-      }
-      dir('output') {
-        // collect and archive service logs
-        echo "Archiving service logs via 'gen3 logs snapshot'"
-        sh(script: "bash ${env.WORKSPACE}/cloud-automation/gen3/bin/logs.sh snapshot", returnStatus: true)
-      }
-      if (testResult != 0) {
-        def failureMsg = "CI Failure on https://github.com/uc-cdis/$REPO_NAME/pull/$PR_NUMBER :facepalm: \n"
-        if (failedTestSuites.size() < 10) {
-          featureLabelMap.each { testSuite, retryLabel ->
-            failureMsg += " - Test Suite *${testSuite}* failed :red_circle: \n To retry, label :label: your PR with *${retryLabel}* \n"
-          }
-        } else {
-          failureMsg += " >10 test suites failed on this PR check :rotating_light:. This might indicate an environmental/config issue. cc: @planxqa :allthethings: :allthethings: :allthethings:"
+  withCredentials(
+    [[$class: 'UsernamePasswordMultiBinding', credentialsId: 'ras-test-user1-for-ci-tests', usernameVariable: 'RAS_TEST_USER_1_USERNAME', passwordVariable: 'RAS_TEST_USER_1_PASSWORD']],
+    [[$class: 'UsernamePasswordMultiBinding', credentialsId: 'ras-test-user2-for-ci-tests', usernameVariable: 'RAS_TEST_USER_2_USERNAME', passwordVariable: 'RAS_TEST_USER_2_PASSWORD']]
+  ) {
+    dir('gen3-qa') {
+      gen3Qa(namespace, {
+        // clean up old test artifacts in the workspace
+        sh "/bin/rm -rf output/ || true"
+        sh "mkdir output"
+        testResult = null
+        List<String> failedTestSuites = [];
+        selectedTests.each {selectedTest ->
+          testResult = sh(script: "bash ./run-tests.sh ${namespace} --service=${service} --testedEnv=${testedEnv} --isGen3Release=${isGen3Release} --selectedTest=${selectedTest}", returnStatus: true);
         }
+        // check XMLs inside the output folder
+        failedTestSuites = xmlHelper.identifyFailedTestSuites()
+        def featureLabelMap = xmlHelper.assembleFeatureLabelMap(failedTestSuites)
 
-        slackSend(color: 'bad', channel: "#gen3-qa-notifications", message: failureMsg)
-        currentBuild.result = 'ABORTED'
-        error("aborting build - testsuite failed")
-      }
-    })
+        if (testResult == 0) {
+          // if the test succeeds, then verify that we got some test results ...
+          testResult = sh(script: "ls output/ | grep '.*\\.xml'", returnStatus: true)
+        }
+        dir('output') {
+          // collect and archive service logs
+          echo "Archiving service logs via 'gen3 logs snapshot'"
+          sh(script: "bash ${env.WORKSPACE}/cloud-automation/gen3/bin/logs.sh snapshot", returnStatus: true)
+        }
+        if (testResult != 0) {
+          def failureMsg = "CI Failure on https://github.com/uc-cdis/$REPO_NAME/pull/$PR_NUMBER :facepalm: \n"
+          if (failedTestSuites.size() < 10) {
+            featureLabelMap.each { testSuite, retryLabel ->
+              failureMsg += " - Test Suite *${testSuite}* failed :red_circle: \n To retry, label :label: your PR with *${retryLabel}* \n"
+            }
+          } else {
+            failureMsg += " >10 test suites failed on this PR check :rotating_light:. This might indicate an environmental/config issue. cc: @planxqa :allthethings: :allthethings: :allthethings:"
+          }
+
+          slackSend(color: 'bad', channel: "#gen3-qa-notifications", message: failureMsg)
+          currentBuild.result = 'ABORTED'
+          error("aborting build - testsuite failed")
+        }
+      })
+    }
   }
 }
 


### PR DESCRIPTION
Introducing `WithCredentials` block to load environment variables with service accounts to be used in CI tests.
The credentials have already been set up in Jenkins.