### PR TITLE
chore(qa): Ignore missing testsuite xmls

### DIFF
--- a/vars/xmlHelper.groovy
+++ b/vars/xmlHelper.groovy
@@ -70,7 +70,7 @@ def identifyFailedTestSuites() {
     }
     println("full list of failedTestSuites: ${failedTestSuites}")
   } catch (e) {
-    println("Something wrong happened: $e")
+    println("Something wrong happened: ${e}")
     println("Ignore and return empty list")
     return [];
   }

--- a/vars/xmlHelper.groovy
+++ b/vars/xmlHelper.groovy
@@ -39,34 +39,40 @@ def assembleFeatureLabelMap(failedTestSuites) {
 
 def identifyFailedTestSuites() {
   List<String> failedTestSuites = [];
-  def xmlTestSuiteFilesRaw = sh(returnStdout: true, script: "ls output/*-testsuite.xml")
-  def xmlTestSuiteFiles = xmlTestSuiteFilesRaw.split('\n')
-  println(xmlTestSuiteFiles)
+  try {
+    def xmlTestSuiteFilesRaw = sh(returnStdout: true, script: "ls output/*-testsuite.xml")
+    def xmlTestSuiteFiles = xmlTestSuiteFilesRaw.split('\n')
+    println(xmlTestSuiteFiles)
 
-  xmlTestSuiteFiles.each{ xmlFile->
-    println('reading test suite file... ' + xmlFile)
+    xmlTestSuiteFiles.each{ xmlFile->
+      println('reading test suite file... ' + xmlFile)
                   
-    def testSuiteName = sh(
-      returnStdout: true,
-      script: "python -c \"import lxml.etree; print(lxml.etree.parse(\\\"${xmlFile}\\\").xpath('//ns2:test-suite/name/text()', namespaces={'ns2': 'urn:model.allure.qatools.yandex.ru'})[0].split(':')[0])\""
-    )
+      def testSuiteName = sh(
+        returnStdout: true,
+        script: "python -c \"import lxml.etree; print(lxml.etree.parse(\\\"${xmlFile}\\\").xpath('//ns2:test-suite/name/text()', namespaces={'ns2': 'urn:model.allure.qatools.yandex.ru'})[0].split(':')[0])\""
+      )
 
-    println(testSuiteName)
+      println(testSuiteName)
 
-    def testSuiteResultsRaw = sh(
-      returnStdout: true,
-      script: "python -c \"import lxml.etree; print(','.join(lxml.etree.parse(\\\"${xmlFile}\\\").xpath('//ns2:test-suite/test-cases/test-case/@status', namespaces={'ns2': 'urn:model.allure.qatools.yandex.ru'})))\""
-    )
+      def testSuiteResultsRaw = sh(
+        returnStdout: true,
+        script: "python -c \"import lxml.etree; print(','.join(lxml.etree.parse(\\\"${xmlFile}\\\").xpath('//ns2:test-suite/test-cases/test-case/@status', namespaces={'ns2': 'urn:model.allure.qatools.yandex.ru'})))\""
+      )
 
-    println('### ##' + StringUtils.chomp(testSuiteResultsRaw).split(","))
+      println('### ##' + StringUtils.chomp(testSuiteResultsRaw).split(","))
 
-    def testSuiteResults = StringUtils.chomp(testSuiteResultsRaw).split(",")
-    println(testSuiteResults)
+      def testSuiteResults = StringUtils.chomp(testSuiteResultsRaw).split(",")
+      println(testSuiteResults)
                   
-    if ('failed' in testSuiteResults) {
-      failedTestSuites.add( StringUtils.chomp(testSuiteName) )
+      if ('failed' in testSuiteResults) {
+        failedTestSuites.add( StringUtils.chomp(testSuiteName) )
+      }
     }
+    println("full list of failedTestSuites: ${failedTestSuites}")
+  } catch (e) {
+    println("Something wrong happened: $e")
+    println("Ignore and return empty list")
+    return [];
   }
-  println("full list of failedTestSuites: ${failedTestSuites}")
   return failedTestSuites
 }


### PR DESCRIPTION
Some PRs are failing with:
```
+ ls output/*-testsuite.xml
ls: cannot access 'output/*-testsuite.xml': No such file or directory
script returned exit code 2
```
Even after the tests are executed successfully. We should ignore missing XMLs.