### PR TITLE
fix(ci): Fix for sower block service account substitution

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -73,10 +73,10 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   println(sowerBlock)
   if (sowerBlock != "null") {
     // set Jenkins CI service accounts for sower jobs if the property exists
-    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' | tee sower_block.json")
-    String sowerBlock2 = sh(returnStdout: true, script: "cat sower_block.json")
+    sh(returnStdout: true, script: "cat sower_block.json | jq -r '.[] | if has(\"serviceAccountName\") then .serviceAccountName = \"jobs-${selectedNamespace}-planx-pla-net\" else . end' > new_scv_acct_sower_block.json")
+    String sowerBlock2 = sh(returnStdout: true, script: "cat new_scv_acct_sower_block.json")
     println(sowerBlock2)
-    sh(returnStdout: true, script: "cat sower_block.json | jq -s . | tee sower_block.json")
+    sh(returnStdout: true, script: "cat new_scv_acct_sower_block.json | jq -s . > sower_block.json")
     String sowerBlock3 = sh(returnStdout: true, script: "cat sower_block.json")
     println(sowerBlock3)
     sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) = \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")


### PR DESCRIPTION
For some mysterious reason, potentially introduced by some recent Jenkins container level update, the manipulation of the sower block to mutate the list of sower-jobs and their correspondent service accounts was impacted and it led to misleading CI failures. More specifically, the sower block file that was supposed to contain the new service accounts is empty after the following operation:
```
cat sower_block.json | jq -r '.[] | if has("serviceAccountName") then .serviceAccountName = "jobs-jenkins-brain-planx-pla-net" else . end' | tee sower_block.json
— Shell Script
<1s
+ jq -r .[] | if has("serviceAccountName") then .serviceAccountName = "jobs-jenkins-brain-planx-pla-net" else . end
+ tee sower_block.json
+ cat sower_block.json
```

This code change has been tested here:
https://github.com/uc-cdis/cdis-manifest/pull/2138/commits/79402db32e5d75eb054334e7cc8ab19f9a7b353f

and it presents the expected output, hence, it is a valid fix.