### PR TITLE
chore(ci2): Also delete svc acct keys for ci-env-1

### DIFF
--- a/vars/microservicePipelineK8s.groovy
+++ b/vars/microservicePipelineK8s.groovy
@@ -189,6 +189,17 @@ spec:
 	  }
         }
       }
+      stage('CleanUp3rdPartyResources') {
+        steps {
+          script {
+            if(!doNotRunTests) {
+              testHelper.deleteGCPServiceAccounts(kubectlNamespace)
+            } else {
+              Utils.markStageSkippedForConditional(STAGE_NAME)
+            }
+          }
+        }
+      }
       stage('ModifyManifest') {
         steps {
           script {

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -191,6 +191,10 @@ def deleteGCPServiceAccounts(jenkinsNamespace) {
       println("deleting jniaid svc accounts");
       JPREFIX="jniaid"
       break;
+    case "ci-env-1":
+      println("deleting cienv1 svc accounts");
+      JPREFIX="cienv1"
+      break;
     default:
       println("invalid jenkins namespace: " + SELECTED_JENKINS_NAMESPACE);
       // If the CI environment is not listed here


### PR DESCRIPTION
Required to support CI runs in qaplanetv2 / jenkins2 (against the experimental `ci-env-1` environment).