### PR TITLE
chore(qa): Avoid misleading 'No such file or directory' error msg

### DIFF
--- a/vars/xmlHelper.groovy
+++ b/vars/xmlHelper.groovy
@@ -46,7 +46,11 @@ def assembleFeatureLabelMap(failedTestSuites) {
 def identifyFailedTestSuites() {
   List<String> failedTestSuites = [];
   try {
-    def xmlTestSuiteFilesRaw = sh(returnStdout: true, script: "ls output/*-testsuite.xml")
+    // avoid "No such file or directory" error if runTests fails before CodeceptJS test reports are generated
+    def xmlTestSuiteFilesRaw = sh(returnStdout: true, script: "[ \"\$(ls -A output)\" ] && ls output/*-testsuite.xml || echo \"Warn: there are no output/*-testsuite.xml files to parse\" ")
+    if (xmlTestSuiteFilesRaw.contains('Warn')) {
+      return [];
+    }
     def xmlTestSuiteFiles = xmlTestSuiteFilesRaw.split('\n')
     println(xmlTestSuiteFiles)
 

--- a/vars/xmlHelper.groovy
+++ b/vars/xmlHelper.groovy
@@ -5,7 +5,7 @@ def assembleFeatureLabelMap(failedTestSuites) {
   def featureLabelMap = [:]
   try {
     // avoid "No such file or directory" error if runTests fails before CodeceptJS test reports are generated
-    def xmlResultFilesRaw = sh(returnStdout: true, script: "[ -d \"output\" ] && ls output/result*.xml || echo \"Warn: there are no output/result-*.xml files to parse\" ")
+    def xmlResultFilesRaw = sh(returnStdout: true, script: "[ \"\$(ls -A output)\" ] && ls output/result*.xml || echo \"Warn: there are no output/result-*.xml files to parse\" ")
     if (xmlResultFilesRaw.contains('Warn')) {
       return null;
     }

--- a/vars/xmlHelper.groovy
+++ b/vars/xmlHelper.groovy
@@ -1,10 +1,11 @@
 import org.apache.commons.lang.StringUtils;
 
+// correlate failed test suites with the script file path from result xmls
 def assembleFeatureLabelMap(failedTestSuites) {
   def featureLabelMap = [:]
   try {
-    // correlate failed test suites with the script file path from result xmls
-    def xmlResultFilesRaw = sh(returnStdout: true, script: "ls output/result*.xml")
+    // always return RC=0 to avoid "No such file or directory" error if runTests fails before CodeceptJS test reports are generated
+    def xmlResultFilesRaw = sh(returnStdout: true, script: "ls output/result*.xml || exit 0")
     def xmlResultFiles = xmlResultFilesRaw.split('\n')
     println(xmlResultFiles)
 
@@ -32,7 +33,9 @@ def assembleFeatureLabelMap(failedTestSuites) {
 
     return featureLabelMap;
   } catch (e) {
-    pipelineHelper.handleError(e)
+    println("Something wrong happened: ${e}")
+    println("Ignore and return null map")
+    return null;
   }
   return null;
 }

--- a/vars/xmlHelper.groovy
+++ b/vars/xmlHelper.groovy
@@ -4,8 +4,11 @@ import org.apache.commons.lang.StringUtils;
 def assembleFeatureLabelMap(failedTestSuites) {
   def featureLabelMap = [:]
   try {
-    // always return RC=0 to avoid "No such file or directory" error if runTests fails before CodeceptJS test reports are generated
-    def xmlResultFilesRaw = sh(returnStdout: true, script: "ls output/result*.xml || exit 0")
+    // avoid "No such file or directory" error if runTests fails before CodeceptJS test reports are generated
+    def xmlResultFilesRaw = sh(returnStdout: true, script: "[ -d \"output\" ] && ls output/result*.xml || echo \"Warn: there are no output/result-*.xml files to parse\" ")
+    if (xmlResultFilesRaw.contains('Warn')) {
+      return null;
+    }
     def xmlResultFiles = xmlResultFilesRaw.split('\n')
     println(xmlResultFiles)
 


### PR DESCRIPTION
Prevent misleading failures in the PR Check if, for whatever reason, the CodeceptJS reports are not created under the `output` folder.
e.g.,
```
full list of failedTestSuites: []
+ ls output/result*.xml
ls: cannot access 'output/result*.xml': No such file or directory
script returned exit code 2ERROR: script returned exit code 2
StackTrace:
hudson.AbortException: script returned exit code 2
```