### PR TITLE
chore(qa): Tweak the environment selection logic

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -61,7 +61,7 @@ def call(Map config) {
               currentBuild.result = 'ABORTED'
               error('This PR is not ready for CI yet, aborting...')
               break
-            case case ~/^jenkins-.*/:
+            case ~/^jenkins-.*/:
               println('found this namespace label! ' + label['name']);
               namespaces.add(label['name'])
               break

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -61,7 +61,7 @@ def call(Map config) {
               currentBuild.result = 'ABORTED'
               error('This PR is not ready for CI yet, aborting...')
               break
-            case AVAILABLE_NAMESPACES:
+            case case ~/^jenkins-.*/:
               println('found this namespace label! ' + label['name']);
               namespaces.add(label['name'])
               break


### PR DESCRIPTION
In order to facilitate the selection of an environment that is "cordoned", we need to improve the logic to pick one of the Jenkins environments in case we need to remove one of them out of the CI pool and utilize it for ephemeral experiments.