### PR TITLE
Revert "chore(midrc): Temporarily removing jenkins-brain from pool of ci envs until the new login/logout flow logic is tested"

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -9,7 +9,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 */
 def call(Map config) {
   node('master') {
-    def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
+    def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
     List<String> namespaces = []
     List<String> selectedTests = []
     doNotRunTests = false


### PR DESCRIPTION
Reverts uc-cdis/cdis-jenkins-lib#134