### PR TITLE
fix(qa): DD URLs can't have hyphens

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -45,7 +45,7 @@ def editService(String commonsHostname, String serviceName, String quayBranchNam
 */
 def setDictionary(String commonsHostname) {
   def prBranchName = env.CHANGE_BRANCH
-  def prRepoName = env.JOB_NAME.split('/')[1];
+  def prRepoName = env.JOB_NAME.split('/')[1].replaceAll('-','');
 
   // branch dictionary
   def branchDictionary = "https://s3.amazonaws.com/dictionary-artifacts/${prRepoName}/${prBranchName}/schema.json"


### PR DESCRIPTION
There’s some automation that deletes any dash / hyphen from the data dictionary repo name right before publishing its branch-based URL.

e.g.,
REPO_NAME = gtex-dictionary
This works:
https://s3.amazonaws.com/dictionary-artifacts/gtexdictionary/chore/testing_this_dd_againstci/schema.json
This doesn’t work:
https://s3.amazonaws.com/dictionary-artifacts/gtex-dictionary/chore/testing_this_dd_againstci/schema.json