### PR TITLE
chore(CI): Fail fast on k8sReset errors

### DIFF
--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -64,7 +64,10 @@ def deploy(String kubectlNamespace) {
 */
 def reset(String kubectlNamespace) {
   kube(kubectlNamespace, {
-    sh "yes | bash ${cloudAutomationPath()}/gen3/bin/reset.sh"
+    resetResult = sh(returnStatus: true, script: "yes | bash ${cloudAutomationPath()}/gen3/bin/reset.sh")
+    if (resultResult != 0) {
+      throw new Exception("The K8s Reset operation failed.")
+    }
     sh "bash ${cloudAutomationPath()}/gen3/bin/kube-setup-spark.sh || true"
   })
 }


### PR DESCRIPTION
Fail fast to avoid misleading errors within the `RunTests` stage.
(e.g., when the usersync orchestrated by the `gen3 reset` fails, it breaks the Gen3-QA boostrapping / cdis.autotest can't create program/projects).