### PR TITLE
chore(ci): Use current time +1hr instead of the starting time of the jenkins build

### DIFF
--- a/vars/quayHelper.groovy
+++ b/vars/quayHelper.groovy
@@ -2,6 +2,8 @@
 * Waits for Quay to finish building the branch in config
 */
 import org.apache.commons.lang.StringUtils;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 def waitForBuild(String repoName, String formattedBranch) {
   if (repoName == "jenkins-lib" || repoName.contains("dictionary")) { return "skip" }
@@ -19,8 +21,12 @@ def waitForBuild(String repoName, String formattedBranch) {
   while(quayImageReady != true && noPendingQuayBuilds != true) {
     noPendingQuayBuilds = true
     currentTime = new Date().getTime()/1000 as Integer
-    println "currentTime is: "+currentTime
-    println "timeout is: "+timeout
+    
+    DateFormat friendlyFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS Z");
+    String timeoutFormatted = friendlyFormat.format(timeout);
+    String currentTimeFormatted = friendlyFormat.format(currentTime);
+    println "currentTime is: " + currentTimeFormatted
+    println "timeout is: " + timeoutFormatted
 
     if(currentTime > timeout) {
       currentBuild.result = 'ABORTED'

--- a/vars/quayHelper.groovy
+++ b/vars/quayHelper.groovy
@@ -7,7 +7,7 @@ def waitForBuild(String repoName, String formattedBranch) {
   if (repoName == "jenkins-lib" || repoName.contains("dictionary")) { return "skip" }
   echo("Waiting for Quay to build:\n  repoName: ${repoName}\n  branch: '${formattedBranch}'\n  commit: ${env.GIT_COMMIT}\n  previous commit: ${env.GIT_PREVIOUS_COMMIT}")
   def timestamp = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) - 3600)
-  def timeout = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) + 3600)
+  def timeout = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) + 5400)
   QUAY_API = 'https://quay.io/api/v1/repository/cdis/'
   timeUrl = "$QUAY_API"+repoName+"/build/?since="+timestamp
   timeQuery = "curl -s "+timeUrl+/ | jq '.builds[] | "\(.tags[]),\(.display_name),\(.phase)"'/

--- a/vars/quayHelper.groovy
+++ b/vars/quayHelper.groovy
@@ -9,7 +9,7 @@ def waitForBuild(String repoName, String formattedBranch) {
   if (repoName == "jenkins-lib" || repoName.contains("dictionary")) { return "skip" }
   echo("Waiting for Quay to build:\n  repoName: ${repoName}\n  branch: '${formattedBranch}'\n  commit: ${env.GIT_COMMIT}\n  previous commit: ${env.GIT_PREVIOUS_COMMIT}")
   def timestamp = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) - 3600)
-  def timeout = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) + 5400)
+  def timeout = (new Date().getTime()) + 3600000
   QUAY_API = 'https://quay.io/api/v1/repository/cdis/'
   timeUrl = "$QUAY_API"+repoName+"/build/?since="+timestamp
   timeQuery = "curl -s "+timeUrl+/ | jq '.builds[] | "\(.tags[]),\(.display_name),\(.phase)"'/


### PR DESCRIPTION
In a recent Jenkins failure we got the following values:
```
currentTime is: 1610573413
GMT: Wednesday, January 13, 2021 9:30:13 PM
Your time zone: Wednesday, January 13, 2021 3:30:13 PM GMT-06:00
```
--
```
timeout is: 1610573358
GMT: Wednesday, January 13, 2021 9:29:18 PM
Your time zone: Wednesday, January 13, 2021 3:29:18 PM GMT-06:00
```

The timeout was at a point one minute before the currentTime.

Which led to the following failure:
```
    if(currentTime > timeout) {
      currentBuild.result = 'ABORTED'
      error("aborting build due to timeout")
    }
```

~Let us bump this up to 90 mins as a temporary measure until this code can be refactored and a better solution comes into play.~

**UPDATE:**
Let us use current time + 1hr instead of the starting time of the jenkins build.