### PR TITLE
Fix/cleanup s3 correctly

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -286,7 +286,7 @@ def call(Map config) {
       stage('CleanS3') {
        try {
         if(!doNotRunTests) {
-          testHelper.cleanS3()
+          testHelper.cleanS3(kubectlNamespace)
 	} else {
 	  Utils.markStageSkippedForConditional(STAGE_NAME)
         }

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -134,35 +134,39 @@ def fetchDataClient(String dataClientBranch="master") {
 
 /**
 * Clean S3
+*
+* @param namespace - namespace to identify the name of the s3 bucket
 */
-def cleanS3() {
-  qaBucket = "qaplanetv1-data-bucket"
-  cleanUpDir = "~/s3-cleanup"
-  localCopy = "$env.WORKSPACE/cleanup-copy.txt"
+def cleanS3(namespace) {
+  gen3Qa(namespace, {
+    qaBucket = "${KUBECTL_NAMESPACE}-databucket-gen3"
+    cleanUpDir = "~/s3-cleanup"
+    localCopy = "$env.WORKSPACE/cleanup-copy.txt"
 
-  filesList = sh(
-    // no error if the dir does not exist or is empty
-    script: "ls -d $cleanUpDir/* || true",
-    returnStdout: true
-  )
+    filesList = sh(
+      // no error if the dir does not exist or is empty
+      script: "ls -d $cleanUpDir/* || true",
+      returnStdout: true
+    )
 
-  // each file contains a list of GUIDs to delete in s3
-  for (filePath in filesList.readLines()) {
-    // move the file to the current workspace so that other jenkins
-    // sessions will not try to use it to clean up
-    try {
-      sh "mv $filePath $localCopy || true"
-      fileContents = new File(localCopy).text
+    // each file contains a list of GUIDs to delete in s3
+    for (filePath in filesList.readLines()) {
+      // move the file to the current workspace so that other jenkins
+      // sessions will not try to use it to clean up
+      try {
+        sh "mv $filePath $localCopy || true"
+        fileContents = new File(localCopy).text
 
-      for (guid in fileContents.readLines()) {
-        // if the file does not exist, no error is thrown
-        sh "aws s3 rm --recursive s3://$qaBucket/$guid"
+        for (guid in fileContents.readLines()) {
+          // if the file does not exist, no error is thrown
+          sh "aws s3 rm --recursive s3://$qaBucket/$guid"
+        }
+
+        sh "rm $localCopy"
       }
-
-      sh "rm $localCopy"
-    }
-    catch (FileNotFoundException e) {
-      // if we can't move it, another session is using it: do nothing
+      catch (FileNotFoundException e) {
+        // if we can't move it, another session is using it: do nothing
+      }
     }
   }
 }

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -168,7 +168,7 @@ def cleanS3(namespace) {
         // if we can't move it, another session is using it: do nothing
       }
     }
-  }
+  })
 }
 
 /**


### PR DESCRIPTION
Jira Ticket: [PXP-7513](https://ctds-planx.atlassian.net/browse/PXP-7513)

We're no longer using a common buckets across all 5 CI environments (`qaplanetv1-data-bucket `), we're now using separate buckets named with the following pattern `${jenkins-namespace}-databucket-gen3`.

### Bug Fixes
- Utilize the correct S3 buckets when cleaning up S3 files generated by data upload tests.
