### PR TITLE
chore(qa): If test suite succeeds on retries, do not suggest its label

### DIFF
--- a/vars/xmlHelper.groovy
+++ b/vars/xmlHelper.groovy
@@ -73,9 +73,11 @@ def identifyFailedTestSuites() {
 
       def testSuiteResults = StringUtils.chomp(testSuiteResultsRaw).split(",")
       println(testSuiteResults)
-                  
-      if ('failed' in testSuiteResults) {
+
+      if ('failed' in testSuiteResults && testSuiteResults.last() != "passed") {
         failedTestSuites.add( StringUtils.chomp(testSuiteName) )
+      } else {
+        println("Test suite succeeded on retries!")
       }
     }
     println("full list of failedTestSuites: ${failedTestSuites}")


### PR DESCRIPTION
The Jenkins notification on Slack is suggesting labels for test suites that are passing tests after retries, this new code should avoid that.