### PR TITLE
fix(ci): Fix QuayHelper logic to give up on failed docker builds

### DIFF
--- a/vars/quayHelper.groovy
+++ b/vars/quayHelper.groovy
@@ -20,7 +20,7 @@ def waitForBuild(String repoName, String formattedBranch) {
   def noPendingQuayBuilds = false
   while(quayImageReady != true && noPendingQuayBuilds != true) {
     noPendingQuayBuilds = true
-    currentTime = new Date().getTime()/1000 as Integer
+    currentTime = new Date().getTime()
     
     DateFormat friendlyFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS Z");
     String timeoutFormatted = friendlyFormat.format(timeout);


### PR DESCRIPTION
Having the current time defined as an Integer is messing with the `currentTime > timeout` check and it's dragging the while pipeline runtime.