### PR TITLE
Chore/experiment with dynamic ci envs pool

### DIFF
--- a/vars/ciEnsPoolHelper.groovy
+++ b/vars/ciEnsPoolHelper.groovy
@@ -1,0 +1,18 @@
+def fetchCIEnvs() {
+  try{
+    jenkins_envs_url="https://gist.githubusercontent.com/themarcelor/35924d625591d6804a1b838f02306819/raw/cc4c80e9562152076efcf811af3cfd175079fbf0/jenkins-envs.txt"
+    println("Shooting a request to: " + jenkins_envs_url);
+    def get = new URL(jenkins_envs_url).openConnection();
+    def getRC = get.getResponseCode();
+    println(getRC);
+    List<String> ciEnvironments = [];    
+    if(getRC.equals(200)) {
+      ciEnvsRaw = get.getInputStream().getText();
+      ciEnvironments = new String( ciEnvsRaw, 'UTF-8' ).split( '\n' )
+    }
+    return ciEnvironments;
+  } catch (e) {
+    pipelineHelper.handleError(e)
+  }
+  return null;
+}

--- a/vars/ciEnsPoolHelper.groovy
+++ b/vars/ciEnsPoolHelper.groovy
@@ -8,7 +8,7 @@ def fetchCIEnvs() {
     List<String> ciEnvironments = [];    
     if(getRC.equals(200)) {
       ciEnvsRaw = get.getInputStream().getText();
-      ciEnvironments = new String( ciEnvsRaw, 'UTF-8' ).split( '\n' )
+      ciEnvironments = ciEnvsRaw.split('\n')
     }
     return ciEnvironments;
   } catch (e) {

--- a/vars/ciEnsPoolHelper.groovy
+++ b/vars/ciEnsPoolHelper.groovy
@@ -1,6 +1,6 @@
 def fetchCIEnvs() {
   try{
-    jenkins_envs_url="https://gist.githubusercontent.com/themarcelor/35924d625591d6804a1b838f02306819/raw/cc4c80e9562152076efcf811af3cfd175079fbf0/jenkins-envs.txt"
+    jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs.txt";
     println("Shooting a request to: " + jenkins_envs_url);
     def get = new URL(jenkins_envs_url).openConnection();
     def getRC = get.getResponseCode();

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -283,24 +283,6 @@ def call(Map config) {
          throw ex
        }
       }
-stage('RunTests') {
-       try {
-        if(!doNotRunTests) {
-          testHelper.runIntegrationTests(
-            kubectlNamespace,
-            pipeConfig.serviceTesting.name,
-            testedEnv,
-            isGen3Release,
-            selectedTests
-          )
-        } else {
-          Utils.markStageSkippedForConditional(STAGE_NAME)
-        }
-       } catch (ex) {
-         metricsHelper.writeMetricWithResult(STAGE_NAME, false)
-         throw ex
-       }
-      }
       stage('CleanS3') {
        try {
         if(!doNotRunTests) {

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -9,7 +9,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 */
 def call(Map config) {
   node('master') {
-    def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
+    def AVAILABLE_NAMESPACES = ciEnsPoolHelper.fetchCIEnvs()
     List<String> namespaces = []
     List<String> selectedTests = []
     doNotRunTests = false
@@ -266,6 +266,24 @@ def call(Map config) {
        metricsHelper.writeMetricWithResult(STAGE_NAME, true)
       }
       stage('RunTests') {
+       try {
+        if(!doNotRunTests) {
+          testHelper.runIntegrationTests(
+            kubectlNamespace,
+            pipeConfig.serviceTesting.name,
+            testedEnv,
+            isGen3Release,
+            selectedTests
+          )
+        } else {
+          Utils.markStageSkippedForConditional(STAGE_NAME)
+        }
+       } catch (ex) {
+         metricsHelper.writeMetricWithResult(STAGE_NAME, false)
+         throw ex
+       }
+      }
+stage('RunTests') {
        try {
         if(!doNotRunTests) {
           testHelper.runIntegrationTests(


### PR DESCRIPTION
Making our list of CI environments dynamic:
https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs.txt

With this change we will be able to mutate the pool of CI environments on the fly.
This is a very powerful mechanism as it will allow us to:
- Lock envs for experiments (taking them out of rotation).
- Cordon environments to protect crime scenes in case we need to conduct some critical investigation.
- This is also a stepping stone for our ephemeral CI envs initiative.

### New Features
- Instead of hardcoding the list of jenkins environments, we will utilize an easily mutable text file hosted in an S3 bucket.