### PR TITLE
chore(ci): Remove portal config if selected env does not have it

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -115,7 +115,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   sh(returnStdout: true, script: "if [ -f \"portal_block.json\" ]; then "
     + "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sp \"\$(cat portal_block.json)\" '(.portal) = \$sp' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
     + "else "
-    + "jq 'del(.portal)' cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json > manifest_tmp.json && mv manifest_tmp.json cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json"
+    + "jq 'del(.portal)' cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json > manifest_tmp.json && mv manifest_tmp.json cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
     + "fi")
   // replace ssjdispatcher block
   sh(returnStdout: true, script: "if [ -f \"ssjdispatcher_block.json\" ]; then "

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -114,6 +114,8 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   // replace Portal block
   sh(returnStdout: true, script: "if [ -f \"portal_block.json\" ]; then "
     + "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sp \"\$(cat portal_block.json)\" '(.portal) = \$sp' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
+    + "else "
+    + "jq 'del(.portal)' cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json > manifest_tmp.json && mv manifest_tmp.json cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json"
     + "fi")
   // replace ssjdispatcher block
   sh(returnStdout: true, script: "if [ -f \"ssjdispatcher_block.json\" ]; then "


### PR DESCRIPTION
e.g.
The following environment's manifest:
https://github.com/uc-cdis/gitops-qa/blob/master/qa-bloodpac.planx-pla.net/manifest.json
does *not* have the portal config block and the nct bundle is being erroneously injected because the `jenkins-niaid` manifest is NOT mutating according to the testedEnv. Therefore, that portal config should be removed for such test cases.