### PR TITLE
chore(night-build): Enable additional tests for our nightly builds

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -54,6 +54,10 @@ def call(Map config) {
               println('Enable additional tests and automation')
               isGen3Release = "true"
               break
+            case "nightly-run":
+              println('Enable additional tests and automation for our nightly-release')
+              isGen3Release = "true"
+              break
             case "debug":
               println("Call npm test with --debug")
               println("leverage CodecepJS feature require('codeceptjs').output.debug feature")


### PR DESCRIPTION
We need to enable ALL test suites for our nightly builds.