### PR TITLE
chore(open-source): Do not abort build for out of date git commits from open source contributions

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -103,11 +103,13 @@ def call(Map config) {
        stage('WaitForQuayBuild') {
          try {
           if(!doNotRunTests) {
-            def currentBranchFormatted = regexMatchRepoOwner[1] == "uc-cdis" ? pipeConfig['currentBranchFormatted'] : "automatedCopy-${pipeConfig['currentBranchFormatted']}";
+            def isOpenSourceContribution = regexMatchRepoOwner[1] != "uc-cdis"
+            def currentBranchFormatted = isOpenSourceContribution ? "automatedCopy-${pipeConfig['currentBranchFormatted']}" : pipeConfig['currentBranchFormatted'];
             println("### ## currentBranchFormatted: ${currentBranchFormatted}")
             quayHelper.waitForBuild(
               pipeConfig['quayRegistry'],
-              currentBranchFormatted
+              currentBranchFormatted,
+              isOpenSourceContribution
             )
 	  } else {
 	    Utils.markStageSkippedForConditional(STAGE_NAME)

--- a/vars/quayHelper.groovy
+++ b/vars/quayHelper.groovy
@@ -5,7 +5,7 @@ import org.apache.commons.lang.StringUtils;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
-def waitForBuild(String repoName, String formattedBranch) {
+def waitForBuild(String repoName, String formattedBranch, def isOpenSourceContribution = false) {
   if (repoName == "jenkins-lib" || repoName.contains("dictionary")) { return "skip" }
   echo("Waiting for Quay to build:\n  repoName: ${repoName}\n  branch: '${formattedBranch}'\n  commit: ${env.GIT_COMMIT}\n  previous commit: ${env.GIT_PREVIOUS_COMMIT}")
   def timestamp = (("${currentBuild.timeInMillis}".substring(0, 10) as Integer) - 3600)
@@ -59,8 +59,12 @@ def waitForBuild(String repoName, String formattedBranch) {
             // things get annoying when quay gets slow
             break
           } else {
-            currentBuild.result = 'ABORTED'
-            error("aborting build due to out of date git hash\npipeline commit: $env.GIT_COMMIT\nquay: "+fields[1])
+            if (!isOpenSourceContribution) {
+              currentBuild.result = 'ABORTED'
+              error("aborting build due to out of date git hash\npipeline commit: $env.GIT_COMMIT\nquay: "+fields[1])
+            } else {
+              println("Open source contribution. Ignore out of date git hash...")
+            }
           }
         }
       }
@@ -94,8 +98,12 @@ def waitForBuild(String repoName, String formattedBranch) {
               // if previous commit is the newest one in quay, then maybe
               // the job's commit hasn't appeared yet. 
               // otherwise assume some other newer commit is in the process of building in quay
-              currentBuild.result = 'ABORTED'
-              error("aborting build due to out of date git hash\ntag: $formattedBranch\npipeline: $env.GIT_COMMIT\nquay: "+fields[1])
+              if (!isOpenSourceContribution) {
+                currentBuild.result = 'ABORTED'
+                error("aborting build due to out of date git hash\ntag: $formattedBranch\npipeline: $env.GIT_COMMIT\nquay: "+fields[1])
+              } else {
+                println("Open source contribution. Ignore out of date git hash...")
+              }
             }
           }
         }


### PR DESCRIPTION
Addressing this issue that is blocking open source contribution testing:
```
ERROR: aborting build due to out of date git hash
pipeline commit: b7770bfe
quay: 53c4a17
StackTrace:
hudson.AbortException: aborting build due to out of date git hash
pipeline commit: b7770bfe
quay: 53c4a17
	at org.jenkinsci.plugins.workflow.steps.ErrorStep$Execution.run(ErrorStep.java:63)
```