### PR TITLE
fix(labels): Restore test suite selection through labels

### DIFF
--- a/vars/githubHelper.groovy
+++ b/vars/githubHelper.groovy
@@ -1,11 +1,11 @@
 import groovy.json.JsonSlurperClassic
 
-def httpApiRequest(String urlPath) {
+def httpApiRequest(String apiContext, String urlPath) {
   try{
     def PR_NUMBER = env.BRANCH_NAME.split('-')[1];
     def REPO_NAME = env.JOB_NAME.split('/')[1];
     println('REPO_NAME: ' + REPO_NAME);
-    pr_url="https://api.github.com/repos/uc-cdis/${REPO_NAME}/pulls/${PR_NUMBER}${urlPath}"
+    pr_url="https://api.github.com/repos/uc-cdis/${REPO_NAME}/${apiContext}/${PR_NUMBER}${urlPath}"
     println("Shooting a request to: " + pr_url);
     def get = new URL(pr_url).openConnection();
     def getRC = get.getResponseCode();
@@ -25,16 +25,17 @@ def httpApiRequest(String urlPath) {
 }
 
 def fetchRepoURL() {
-  def prMetadata = httpApiRequest("")  
+  def prMetadata = httpApiRequest("pulls", "")
   return prMetadata['head']['repo']['url'];
 }
 
 def fetchLabels() {
-  def prMetadata = httpApiRequest("/labels")
+  def prMetadata = httpApiRequest("issues", "/labels")
+  println("### ## Labels: ${prMetadata}")
   return prMetadata;
 }
 
 def isDraft() {
-  def prMetadata = httpApiRequest("")
+  def prMetadata = httpApiRequest("pulls", "")
   return prMetadata['draft'];
 }


### PR DESCRIPTION
While delivering some refactoring code for the open source contributions’ automation…
I broke the test suite selection through labels 😄  So all PRs are running ALL tests (labels are being ignored).

That’s because we obtain PR metadata through an URL like this:
`https://api.github.com/repos/uc-cdis/cdis-manifest/pulls/2822`
BUT, for labels, the Github API designers thought it would be a good idea to change that URL context to issues instead of pulls 🤦🏼 
`e.g., https://api.github.com/repos/uc-cdis/cdis-manifest/issues/2822/labels`