### PR TITLE
fix(k8s-debugging): Drop logs on root folder of the PR workspace

### DIFF
--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -89,7 +89,6 @@ def saveLogs(String kubectlNamespace) {
     saveLogsResult = sh(returnStatus: true, script: """
       #!/bin/bash
       bash ${cloudAutomationPath()}/gen3/bin/save-failed-pod-logs.sh
-      mv *.log gen3-qa/output/
     """)
     if (saveLogsResult != 0) {
       throw new Exception("The Gen3 save logs operation failed.")

--- a/vars/pipelineHelper.groovy
+++ b/vars/pipelineHelper.groovy
@@ -82,7 +82,7 @@ def handleError(e) {
 def teardown(String buildResult) {
   archiveArtifacts(artifacts: '**/output/*.png', allowEmptyArchive: true)
   archiveArtifacts(artifacts: '**/output/*.log.gz', allowEmptyArchive: true)
-  archiveArtifacts(artifacts: '**/output/*.log', allowEmptyArchive: true)
+  archiveArtifacts(artifacts: '*.log', allowEmptyArchive: true)
 
   if ("UNSTABLE" == buildResult) {
     echo "Build Unstable!"


### PR DESCRIPTION
fix this issue:
```
+ bash /var/jenkins_home/workspace/GitHub_Org_cdis-manifest_PR-2848/cloud-automation/gen3/bin/save-failed-pod-logs.sh
INFO: 22:10:41 - capturing and archiving logs from failed pods (if any)...
+ mv save-failed-pod-logs.log gen3-qa/output/
mv: cannot move 'save-failed-pod-logs.log' to 'gen3-qa/output/': Not a directory
The Gen3 save logs operation failed.
```