### PR TITLE
chore(ci-observability): Send slack notifications for K8sReset failures

### DIFF
--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -104,7 +104,7 @@ def sendSlackNotification(String kubectlNamespace, String isNightlyBuild = "fals
       // include url in the notification (e.g., # https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcdis-manifest/detail/PR-2503/7/pipeline)
       def PR_NUMBER = env.BRANCH_NAME.split('-')[1];
       def REPO_NAME = env.JOB_NAME.split('/')[1];
-      slackSend(color: 'bad', channel: isNightlyBuild == "true" ? "#nightly-builds" : "#gen3-qa-notifications", message: "OH NOUS! :open_mouth: K8sReset failed :rotating_light: on ${kubectlNamespace}. Go check the failing pods / logs here: https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2F${REPO_NAME}/detail/${PR_NUMBER}/${env.BUILD_NUMBER}/pipeline .")
+      slackSend(color: 'bad', channel: isNightlyBuild == "true" ? "#nightly-builds" : "#gen3-qa-notifications", message: "OH NOUS! :open_mouth: K8sReset failed :rotating_light: on ${kubectlNamespace}. Go check the failing pods / logs here: https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2F${REPO_NAME}/detail/PR-${PR_NUMBER}/${env.BUILD_NUMBER}/pipeline .")
     }
   )
 }

--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -97,6 +97,19 @@ def saveLogs(String kubectlNamespace) {
 }
 
 /**
+* Send Slack notifications to improve observability on k8sReset failures
+*/
+def sendSlackNotifications(String kubectlNamespace, String isNightlyBuild = "false") {
+  kube(kubectlNamespace, {
+      // include url in the notification (e.g., # https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcdis-manifest/detail/PR-2503/7/pipeline)
+      def PR_NUMBER = env.BRANCH_NAME.split('-')[1];
+      def REPO_NAME = env.JOB_NAME.split('/')[1];
+      slackSend(color: 'bad', channel: isNightlyBuild == "true" ? "#nightly-builds" : "#gen3-qa-notifications", message: "OH NOUS! :open_mouth: K8sReset failed :rotating_light: on ${kubectlNamespace}. Go check the failing pods / logs here: https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2F${REPO_NAME}/detail/${PR_NUMBER}/${env.BUILD_NUMBER}/pipeline .")
+    }
+  })
+}
+
+/**
 * Map for storing locks
 */
 def newKubeLock(String kubectlNamespace, String lockOwner, String lockName) {

--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -106,7 +106,7 @@ def sendSlackNotifications(String kubectlNamespace, String isNightlyBuild = "fal
       def REPO_NAME = env.JOB_NAME.split('/')[1];
       slackSend(color: 'bad', channel: isNightlyBuild == "true" ? "#nightly-builds" : "#gen3-qa-notifications", message: "OH NOUS! :open_mouth: K8sReset failed :rotating_light: on ${kubectlNamespace}. Go check the failing pods / logs here: https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2F${REPO_NAME}/detail/${PR_NUMBER}/${env.BUILD_NUMBER}/pipeline .")
     }
-  })
+  )
 }
 
 /**

--- a/vars/kubeHelper.groovy
+++ b/vars/kubeHelper.groovy
@@ -99,7 +99,7 @@ def saveLogs(String kubectlNamespace) {
 /**
 * Send Slack notifications to improve observability on k8sReset failures
 */
-def sendSlackNotifications(String kubectlNamespace, String isNightlyBuild = "false") {
+def sendSlackNotification(String kubectlNamespace, String isNightlyBuild = "false") {
   kube(kubectlNamespace, {
       // include url in the notification (e.g., # https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcdis-manifest/detail/PR-2503/7/pipeline)
       def PR_NUMBER = env.BRANCH_NAME.split('-')[1];

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -232,6 +232,7 @@ def call(Map config) {
         }
        } catch (ex) {
          metricsHelper.writeMetricWithResult(STAGE_NAME, false)
+         kubeHelper.sendSlackNotification(kubectlNamespace, isNightlyBuild)
          kubeHelper.saveLogs(kubectlNamespace)
          throw ex
        }


### PR DESCRIPTION
Send slack notifications for K8sReset failures with URL.
This should give us a feeling of how often we face such failures (in addition to metrics on https://qa.planx-pla.net/grafana/d/qiqUaOgMz/ci-metrics).