### PR TITLE
chore(ci-observability): hudson.AbortException should not be considered a k8sReset failure

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -232,7 +232,8 @@ def call(Map config) {
         }
        } catch (ex) {
          // ignore aborted pipelines (not a failure, just some subsequent commit that initiated a new build)
-         if (ex.getClass().getCanonicalName() != "hudson.AbortException") {
+         if (ex.getClass().getCanonicalName() != "hudson.AbortException") && 
+            (ex.getClass().getCanonicalName() != "org.jenkinsci.plugins.workflow.steps.FlowInterruptedException") {
            metricsHelper.writeMetricWithResult(STAGE_NAME, false)
            kubeHelper.sendSlackNotification(kubectlNamespace, isNightlyBuild)
            kubeHelper.saveLogs(kubectlNamespace)

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -232,8 +232,8 @@ def call(Map config) {
         }
        } catch (ex) {
          // ignore aborted pipelines (not a failure, just some subsequent commit that initiated a new build)
-         if (ex.getClass().getCanonicalName() != "hudson.AbortException") && 
-            (ex.getClass().getCanonicalName() != "org.jenkinsci.plugins.workflow.steps.FlowInterruptedException") {
+         if (ex.getClass().getCanonicalName() != "hudson.AbortException" && 
+            ex.getClass().getCanonicalName() != "org.jenkinsci.plugins.workflow.steps.FlowInterruptedException") {
            metricsHelper.writeMetricWithResult(STAGE_NAME, false)
            kubeHelper.sendSlackNotification(kubectlNamespace, isNightlyBuild)
            kubeHelper.saveLogs(kubectlNamespace)

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -231,9 +231,12 @@ def call(Map config) {
           Utils.markStageSkippedForConditional(STAGE_NAME)
         }
        } catch (ex) {
-         metricsHelper.writeMetricWithResult(STAGE_NAME, false)
-         kubeHelper.sendSlackNotification(kubectlNamespace, isNightlyBuild)
-         kubeHelper.saveLogs(kubectlNamespace)
+         // ignore aborted pipelines (not a failure, just some subsequent commit that initiated a new build)
+         if (ex.getClass().getCanonicalName() != "hudson.AbortException") {
+           metricsHelper.writeMetricWithResult(STAGE_NAME, false)
+           kubeHelper.sendSlackNotification(kubectlNamespace, isNightlyBuild)
+           kubeHelper.saveLogs(kubectlNamespace)
+         }
          throw ex
        }
        metricsHelper.writeMetricWithResult(STAGE_NAME, true)


### PR DESCRIPTION
Let us avoid false alerts and noise on #gen3-qa-notifications