### PR TITLE
Fix: delete netpolicy in jenkins when target environment manifest does not have it

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -134,7 +134,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   // delete netpolicy if the manifest from the target enviroment does not have it
   if (netpolicyStatus != 0){
     sh(returnStdout: true, script:
-    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r -argjson sp 'del(.global.netpolicy) = \$sp' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
+    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r 'del(.global.netpolicy)' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json "
     )
   }
 

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -69,6 +69,8 @@ def setDictionary(String commonsHostname) {
 def mergeManifest(String changedDir, String selectedNamespace) {
   String od = sh(returnStdout: true, script: "jq -r .global.dictionary_url < tmpGitClone/$changedDir/manifest.json").trim()
   String pa = sh(returnStdout: true, script: "jq -r .global.portal_app < tmpGitClone/$changedDir/manifest.json").trim()
+  // fetch netpolicy from the target environment
+  netpolicyStatus = sh(returnStatus : true, script: "cat tmpGitClone/$changedDir/manifest.json | jq --exit-status '.global.netpolicy'")
   // fetch sower block from the target environment
   sh "jq -r .sower < tmpGitClone/$changedDir/manifest.json > sower_block.json"
   // fetch portal block from the target environment
@@ -83,8 +85,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   sh(returnStdout: true, script: "if cat tmpGitClone/$changedDir/manifest.json | jq --exit-status '.indexd' >/dev/null; then "
     + "jq -r .indexd < tmpGitClone/$changedDir/manifest.json > indexd_block.json; "
     + "fi")
-  // fetch netpolicy from the target environment
-  netpolicyStatus = sh(returnStatus : true, script: "cat tmpGitClone/$changedDir/manifest.json | jq --exit-status '.global.netpolicy'")
+  
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)
@@ -117,6 +118,12 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     println(sowerBlock3)
     sh(returnStdout: true, script: "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sj \"\$(cat sower_block.json)\" '(.sower) = \$sj' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   }
+  // delete netpolicy if the manifest from the target enviroment does not have it
+  if (netpolicyStatus != 0){
+    sh(returnStdout: true, script:
+    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r 'del(.global.netpolicy)' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json "
+    )
+  }
   // replace Portal block
   sh(returnStdout: true, script: "if [ -f \"portal_block.json\" ]; then "
     + "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sp \"\$(cat portal_block.json)\" '(.portal) = \$sp' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
@@ -131,12 +138,6 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   sh(returnStdout: true, script: "if [ -f \"indexd_block.json\" ]; then "
     + "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sp \"\$(cat indexd_block.json)\" '(.indexd) = \$sp' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
     + "fi")
-  // delete netpolicy if the manifest from the target enviroment does not have it
-  if (netpolicyStatus != 0){
-    sh(returnStdout: true, script:
-    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r 'del(.global.netpolicy)' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json "
-    )
-  }
 
   String rs = sh(returnStdout: true, script: "cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   return rs

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -84,8 +84,8 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     + "jq -r .indexd < tmpGitClone/$changedDir/manifest.json > indexd_block.json; "
     + "fi")
   // fetch netpolicy from the target environment
-  netpolicyFromTargetEnv = sh(returnStdout: true, script: "cat tmpGitClone/$changedDir/manifest.json | jq .global.netpolicy")
-
+  sh(returnStdout: true, script: "cat tmpGitClone/$changedDir/manifest.json | jq .global.netpolicy")
+  netpolicyStatus = sh(returnStdout: true, script:"echo $?")
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)
@@ -133,7 +133,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     + "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r --argjson sp \"\$(cat indexd_block.json)\" '(.indexd) = \$sp' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
     + "fi")
   // delete netpolicy if the manifest from the target enviroment does not have it
-  if (netpolicyFromTargetEnv == "null"){
+  if (netpolicyStatus != 0){
     sh(returnStdout: true, script:
     "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq 'del(.global.netpolicy)' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
     )

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -134,7 +134,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   // delete netpolicy if the manifest from the target enviroment does not have it
   if (netpolicyStatus != 0){
     sh(returnStdout: true, script:
-    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r 'del(.global.netpolicy)' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
+    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r -argjson sp 'del(.global.netpolicy) = \$sp' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
     )
   }
 

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -134,7 +134,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
   // delete netpolicy if the manifest from the target enviroment does not have it
   if (netpolicyStatus != 0){
     sh(returnStdout: true, script:
-    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq 'del(.global.netpolicy)' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
+    "old=\$(cat cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json) && echo \$old | jq -r 'del(.global.netpolicy)' > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json; "
     )
   }
 

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -84,8 +84,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     + "jq -r .indexd < tmpGitClone/$changedDir/manifest.json > indexd_block.json; "
     + "fi")
   // fetch netpolicy from the target environment
-  sh(returnStdout: true, script: "cat tmpGitClone/$changedDir/manifest.json | jq .global.netpolicy")
-  netpolicyStatus = sh(returnStdout: true, script:"echo $?")
+  netpolicyStatus = sh(returnStatus : true, script: "cat tmpGitClone/$changedDir/manifest.json | jq --exit-status '.global.netpolicy'")
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s
   def keys = new groovy.json.JsonSlurper().parseText(s)

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -84,7 +84,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
     + "jq -r .indexd < tmpGitClone/$changedDir/manifest.json > indexd_block.json; "
     + "fi")
   // fetch netpolicy from the target environment
-  netpolicyFromTargetEnv = sh(returnStdout: true, script: "if cat tmpGitClone/$changedDir/manifest.json | jq .global.netpolicy")
+  netpolicyFromTargetEnv = sh(returnStdout: true, script: "cat tmpGitClone/$changedDir/manifest.json | jq .global.netpolicy")
 
   String s = sh(returnStdout: true, script: "jq -r keys < cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
   println s


### PR DESCRIPTION
If the target environment manifest doesn’t have netpolicy, we need to delete the `netpolicy: "on"`  from the jenkins-* manifest.json and then `$ gen3 kube-setup-indexd`  will NOT create the network policies