### PR TITLE
chore(ci): Create bridge function to support typo for old cloud-automation PRs

### DIFF
--- a/vars/ciEnsPoolHelper.groovy
+++ b/vars/ciEnsPoolHelper.groovy
@@ -1,0 +1,3 @@
+def fetchCIEnvs() {
+  return ciEnvsHelper.fetchCIEnvs()
+}


### PR DESCRIPTION
This is a workaround to support the replay function on old cloud-automation PRs.