### PR TITLE
Fix: Allow empty junit result when doNotRunTest is true

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -415,7 +415,7 @@ def call(Map config) {
     finally {
       stage('Post') {
         kubeHelper.teardown(kubeLocks)
-        testHelper.teardown()
+        testHelper.teardown(doNotRunTests)
         pipelineHelper.teardown(currentBuild.result)
       }
     }

--- a/vars/microservicePipelineK8s.groovy
+++ b/vars/microservicePipelineK8s.groovy
@@ -336,7 +336,7 @@ spec:
       always {
         script {
           kubeHelper.teardown(kubeLocks)
-          testHelper.teardown()
+          testHelper.teardown(doNotRunTests)
           pipelineHelper.teardown(currentBuild.result)
 	}
       }

--- a/vars/performancePipeline.groovy
+++ b/vars/performancePipeline.groovy
@@ -74,7 +74,7 @@ def call(body) {
           sh "rm -rf DataImportOrder.txt"
         }
         kubeHelper.teardown(kubeLocks)
-        testHelper.teardown()
+        testHelper.teardown(false)
 
         if (env.CHANGE_ID) {
           def r = junitReport.junitReportTable()

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -384,11 +384,16 @@ def checkPodHealth(String namespace, String testedEnv) {
   }
 }
 
-def teardown() {
+def teardown(allowEmpty) {
   // try to analyze junit files
   // result xml file may not exist due to pipeline or test suite failures
   try {
-    junit "gen3-qa/output/*.xml"
+    if(allowEmpty){
+      junit testResults: "gen3-qa/output/*.xml", allowEmptyResults: true
+    }
+    else{
+      junit "gen3-qa/output/*.xml"
+    }
   }
   catch(e) {
     def st = new StringWriter()


### PR DESCRIPTION
Fix this issue: 

> jenkins failed twice in a row with error No test report files were found. Configuration error? after skipping the tests with label doc-only