### PR TITLE
fix(ci): fix jq instruction to print sower_block.json

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -106,7 +106,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
           + """&& echo \$old | jq -r --arg od ${od} --arg pa ${pa} --argjson vs \"\$bs\"""" 
           + / '(.global.dictionary_url) |=/ + "\$od" + / | (.global.portal_app) |=/ + "\$pa"
           + / | (.versions) |=/ + "\$vs" + /'/ + " > cdis-manifest/${selectedNamespace}.planx-pla.net/manifest.json")
-  String parseSowerBlockReturnCode = sh(returnStatus: true, script: "jq sower_block.json")
+  String parseSowerBlockReturnCode = sh(returnStatus: true, script: "jq -r '.' sower_block.json")
   println(parseSowerBlockReturnCode)
   if (parseSowerBlockReturnCode == "0") {
     // set Jenkins CI service accounts for sower jobs if the property exists


### PR DESCRIPTION
Fixing this error:
```
jenkins@jenkins-deployment-87585c94-dmr5t:~/workspace/GitHub_Org_cdis-manifest_PR-2933$ jq sower_block.json
jq: error: sower_block/0 is not defined at <top-level>, line 1:
sower_block.json
jq: 1 compile error
```