### PR TITLE
fix(nightly-build): testedEnv should be determined by global config, not by git diff folder

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -214,7 +214,7 @@ def call(Map config) {
         stage('ModifyManifest') {
          try {
           if(!doNotRunTests) {
-            testedEnv = manifestHelper.manifestDiff(kubectlNamespace)
+            testedEnv = kubeHelper.getHostname(kubectlNamespace)
 	  } else {
 	    Utils.markStageSkippedForConditional(STAGE_NAME)
           }
@@ -224,10 +224,6 @@ def call(Map config) {
          }
          metricsHelper.writeMetricWithResult(STAGE_NAME, true)
 	}
-      } else {
-        if(!doNotRunTests) {
-          testedEnv = kubeHelper.getHostname(kubectlNamespace)
-        }
       }
 
       stage('K8sReset') {

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -214,7 +214,7 @@ def call(Map config) {
         stage('ModifyManifest') {
          try {
           if(!doNotRunTests) {
-            testedEnv = kubeHelper.getHostname(kubectlNamespace)
+            kubeHelper.getHostname(kubectlNamespace)
 	  } else {
 	    Utils.markStageSkippedForConditional(STAGE_NAME)
           }
@@ -225,6 +225,9 @@ def call(Map config) {
          metricsHelper.writeMetricWithResult(STAGE_NAME, true)
 	}
       }
+
+      // set variable to identify which environment is being tested:
+      testedEnv = kubeHelper.getHostname(kubectlNamespace)
 
       stage('K8sReset') {
        try {

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -215,8 +215,8 @@ def call(Map config) {
          try {
           if(!doNotRunTests) {
             manifestHelper.manifestDiff(kubectlNamespace)
-	  } else {
-	    Utils.markStageSkippedForConditional(STAGE_NAME)
+          } else {
+            Utils.markStageSkippedForConditional(STAGE_NAME)
           }
          } catch (ex) {
            metricsHelper.writeMetricWithResult(STAGE_NAME, false)

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -214,7 +214,7 @@ def call(Map config) {
         stage('ModifyManifest') {
          try {
           if(!doNotRunTests) {
-            kubeHelper.getHostname(kubectlNamespace)
+            manifestHelper.manifestDiff(kubectlNamespace)
 	  } else {
 	    Utils.markStageSkippedForConditional(STAGE_NAME)
           }


### PR DESCRIPTION
If we obtain the `testedEnv` value from the `environment` parameter found inside the corresponding `manifest.json`'s global config block, that will be a more accurate way of making our automated tests aware of which environment is being tested.

Explaining the issue:
The nightly build job picks one environment at random:
```
commons=("gen3.theanvil.io" "chicagoland.pandemicresponsecommons.org" "gen3.biodatacatalyst.nhlbi.nih.gov" "nci-crdc.datacommons.io" "data.braincommons.org" "vpodc.org")
# Selects one randomly
selectedCommons=${commons[$RANDOM % ${#commons[@]} ]}
```
But the name of the folder is still nightly.planx-pla.net , and that folder name is passed on to the testing framework as a testedEnv variable.
That `testedEnv` variable is used to determine which Selenium locators (css id / class, xpath, etc.) should be utilized to run assertions.

So, last night, the job picked up:
```
[Nightly(05-18-2021) 1be85949] nightly build 05-18-2021, using chicagoland.pandemicresponsecommons.org
```
Which was supposed to use the following css IDs for web page rendering assertions:
https://github.com/uc-cdis/gen3-qa/blob/master/utils/apiUtil.js#L428
```
      pandemicresponsecommons: {
        summary: {
          css: '.covid19-dashboard_panel',
        },
        cards: {
          css: '.covid19-dashboard_counts',
        },
```
but because `testedEnv="nightly.planx-pla.net"`, it never pulled the config from the `pandemicresponsecommons` map key.