### PR TITLE
chore(ci): Introduce diff pools of environments

### DIFF
--- a/vars/ciEnvsHelper.groovy
+++ b/vars/ciEnvsHelper.groovy
@@ -1,6 +1,11 @@
-def fetchCIEnvs() {
+def fetchCIEnvs(pipeconfigManifest) {
   try{
-    jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs.txt";
+    def jenkins_envs_url = ""
+    if (pipeConfig.MANIFEST == null || pipeConfig.MANIFEST == false || pipeConfig.MANIFEST != "True") {
+      jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-services.txt";
+    } else {
+      jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-releases.txt";
+    }
     println("Shooting a request to: " + jenkins_envs_url);
     def get = new URL(jenkins_envs_url).openConnection();
     def getRC = get.getResponseCode();

--- a/vars/ciEnvsHelper.groovy
+++ b/vars/ciEnvsHelper.groovy
@@ -1,7 +1,7 @@
 def fetchCIEnvs(pipeconfigManifest) {
   try{
     def jenkins_envs_url = ""
-    if (pipeConfig.MANIFEST == null || pipeConfig.MANIFEST == false || pipeConfig.MANIFEST != "True") {
+    if (pipeconfigManifest == null || pipeconfigManifest == false || pipeconfigManifest != "True") {
       jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-services.txt";
     } else {
       jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-releases.txt";

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -9,7 +9,6 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 */
 def call(Map config) {
   node('master') {
-    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs()
     List<String> namespaces = []
     List<String> selectedTests = []
     doNotRunTests = false
@@ -21,6 +20,7 @@ def call(Map config) {
     kubeLocks = []
     testedEnv = "" // for manifest pipeline
     pipeConfig = pipelineHelper.setupConfig(config)
+    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(pipeConfig.MANIFEST)
     pipelineHelper.cancelPreviousRunningBuilds()
     prLabels = githubHelper.fetchLabels()
 


### PR DESCRIPTION
To obtain some control over the throughput of PRs / Jenkins tests between repos, we are splitting the pool of environments between:
- jenkins-envs-services.txt
and
- jenkins-envs-releases.txt

```
% curl -s https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-services.txt
jenkins-genomel
jenkins-blood
jenkins-dcp
jenkins-brain
jenkins-niaid
% curl -s https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-releases.txt
jenkins-genomel
jenkins-blood
jenkins-dcp
jenkins-brain
jenkins-niaid
```

All cdis-manifest PRs will fetch the pool of CI environments from `jenkins-envs-releases.txt` whereas all the service repo PRs will fetch CI envs from `jenkins-envs-services.txt`.
If we want to keep a balance between the PRs across all repos balance, we just leave 5 jenkins environments in both files.
If we want to increase the throughput of cdis-manifest PRs to unblock critical releases faster. We remove jenkins envs from `jenkins-envs-services.txt`.