### PR TITLE
chore(ci): Introduce special label to run PR check on separate jenkins-ci-worker pod

### DIFF
--- a/vars/ciEnvsHelper.groovy
+++ b/vars/ciEnvsHelper.groovy
@@ -1,9 +1,7 @@
-def fetchCIEnvs(theNode = 'master') {
+def fetchCIEnvs(pipeconfigManifest = false, theNode = 'master') {
   try{
-    def jenkins_envs_url = ""
-    if (theNode == "master") {
-      jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-services.txt";
-    } else {
+    def jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-services.txt";
+    if (pipeconfigManifest == "True" || theNode == 'gen3-ci-worker') {
       jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-releases.txt";
     }
     println("Shooting a request to: " + jenkins_envs_url);

--- a/vars/ciEnvsHelper.groovy
+++ b/vars/ciEnvsHelper.groovy
@@ -1,7 +1,7 @@
-def fetchCIEnvs(pipeconfigManifest = false) {
+def fetchCIEnvs(theNode = 'master') {
   try{
     def jenkins_envs_url = ""
-    if (pipeconfigManifest == null || pipeconfigManifest == false || pipeconfigManifest != "True") {
+    if (theNode == "master") {
       jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-services.txt";
     } else {
       jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-releases.txt";
@@ -10,7 +10,7 @@ def fetchCIEnvs(pipeconfigManifest = false) {
     def get = new URL(jenkins_envs_url).openConnection();
     def getRC = get.getResponseCode();
     println(getRC);
-    List<String> ciEnvironments = [];    
+    List<String> ciEnvironments = [];
     if(getRC.equals(200)) {
       ciEnvsRaw = get.getInputStream().getText();
       ciEnvironments = ciEnvsRaw.split('\n')

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -4,18 +4,28 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 /**
 * Pipline for building and testing microservices
-* 
+*
 * @param config - pipeline configuration
 */
 def call(Map config) {
-  node('master') {
+
+  // check if PR contains a label to define where the PR check must run
+  // giving a chance for auto-label gh actions to catch up
+  sleep(30)
+  def prLabels = githubHelper.fetchLabels()
+
+  // run all PR checks on jenkins-master by default
+  def theNode = 'master'
+  if (prLabels.contains('run-on-jenkins-ci-worker'))) {
+    theNode = 'gen3-ci-worker'
+  }
+  node(theNode) {
     List<String> namespaces = []
     List<String> selectedTests = []
     doNotRunTests = false
     runParallelTests = false
     isGen3Release = "false"
     isNightlyBuild = "false"
-    prLabels = null
     kubectlNamespace = null
     kubeLocks = []
     testedEnv = "" // for manifest pipeline
@@ -32,10 +42,6 @@ def call(Map config) {
       }
       stage('CheckPRLabels') {
        try {
-        // giving a chance for auto-label gh actions to catch up
-        sleep(30)
-        prLabels = githubHelper.fetchLabels()
-
         // if the changes are doc-only, automatically skip the tests
         doNotRunTests = doNotRunTests || docOnlyHelper.checkTestSkippingCriteria()
 
@@ -96,7 +102,7 @@ def call(Map config) {
 	  selectedTests.add("all")
         }
        } catch (ex) {
-        metricsHelper.writeMetricWithResult(STAGE_NAME, false)  
+        metricsHelper.writeMetricWithResult(STAGE_NAME, false)
         throw ex
        }
        metricsHelper.writeMetricWithResult(STAGE_NAME, true)
@@ -164,7 +170,7 @@ def call(Map config) {
               )
             } else {
               def quayBranchName = regexMatchRepoOwner[1] == "uc-cdis" ? pipeConfig.serviceTesting.branch : "automatedCopy-${pipeConfig.serviceTesting.branch}";
-              println("### ## quayBranchName: ${quayBranchName}")            
+              println("### ## quayBranchName: ${quayBranchName}")
               manifestHelper.editService(
                 kubeHelper.getHostname(kubectlNamespace),
                 pipeConfig.serviceTesting.name,
@@ -242,7 +248,7 @@ def call(Map config) {
         }
        } catch (ex) {
          // ignore aborted pipelines (not a failure, just some subsequent commit that initiated a new build)
-         if (ex.getClass().getCanonicalName() != "hudson.AbortException" && 
+         if (ex.getClass().getCanonicalName() != "hudson.AbortException" &&
             ex.getClass().getCanonicalName() != "org.jenkinsci.plugins.workflow.steps.FlowInterruptedException") {
            metricsHelper.writeMetricWithResult(STAGE_NAME, false)
            kubeHelper.sendSlackNotification(kubectlNamespace, isNightlyBuild)

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -16,7 +16,7 @@ def call(Map config) {
 
   // run all PR checks on jenkins-master by default
   def theNode = 'master'
-  if (prLabels.contains('run-on-jenkins-ci-worker'))) {
+  if (prLabels.contains('run-on-jenkins-ci-worker')) {
     theNode = 'gen3-ci-worker'
   }
   node(theNode) {

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -31,7 +31,7 @@ def call(Map config) {
     kubeLocks = []
     testedEnv = "" // for manifest pipeline
     pipeConfig = pipelineHelper.setupConfig(config)
-    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(theNode)
+    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(pipeConfig.MANIFEST, theNode)
     pipelineHelper.cancelPreviousRunningBuilds()
 
     try {

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -31,7 +31,7 @@ def call(Map config) {
     kubeLocks = []
     testedEnv = "" // for manifest pipeline
     pipeConfig = pipelineHelper.setupConfig(config)
-    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(pipeConfig.MANIFEST)
+    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(theNode)
     pipelineHelper.cancelPreviousRunningBuilds()
 
     try {

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -13,11 +13,10 @@ def call(Map config) {
   // giving a chance for auto-label gh actions to catch up
   sleep(30)
   def prLabels = githubHelper.fetchLabels()
-  println("check list of labels: $prLabels")
 
   // run all PR checks on jenkins-master by default
   def theNode = 'master'
-  if (prLabels.contains('run-on-jenkins-ci-worker')) {
+  if (prLabels.any{label -> label.name == "run-on-jenkins-ci-worker"}) {
     println('Found [run-on-jenkins-ci-worker] label, running CI on ci worker pod...')
     theNode = 'gen3-ci-worker'
   }

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -13,10 +13,12 @@ def call(Map config) {
   // giving a chance for auto-label gh actions to catch up
   sleep(30)
   def prLabels = githubHelper.fetchLabels()
+  println("check list of labels: $prLabels")
 
   // run all PR checks on jenkins-master by default
   def theNode = 'master'
   if (prLabels.contains('run-on-jenkins-ci-worker')) {
+    println('Found [run-on-jenkins-ci-worker] label, running CI on ci worker pod...')
     theNode = 'gen3-ci-worker'
   }
   node(theNode) {


### PR DESCRIPTION
If we suspect jenkins-master is overwhelmed, we can send PR check jobs to this jenkins-ci-worker pod.