### PR TITLE
chore(ci-throughput): All manifest PRs should run on gen3-ci-worker

### DIFF
--- a/vars/ciEnvsHelper.groovy
+++ b/vars/ciEnvsHelper.groovy
@@ -1,7 +1,7 @@
-def fetchCIEnvs(pipeconfigManifest = false, theNode = 'master') {
+def fetchCIEnvs(runOnGen3CIWorker = false) {
   try{
     def jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-services.txt";
-    if (pipeconfigManifest == "True" || theNode == 'gen3-ci-worker') {
+    if (runOnGen3CIWorker == "True") {
       jenkins_envs_url="https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs-releases.txt";
     }
     println("Shooting a request to: " + jenkins_envs_url);

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -19,7 +19,7 @@ def call(Map config) {
     println('Found [run-on-jenkins-ci-worker] label, running CI on ci worker pod...')
     runOnGen3CIWorker = true
   }
-  node(theNode) {
+  node(runOnGen3CIWorker? 'gen3-ci-worker' : 'master') {
     List<String> namespaces = []
     List<String> selectedTests = []
     doNotRunTests = false

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -33,7 +33,7 @@ def call(Map config) {
 
     // if this is a Manifests repo, run on separate jenkins worker pod
     // this is overridable by the 'run-on-jenkins-ci-worker' PR label
-    if (pipeconfigManifest == "True") {
+    if (pipeConfig.MANIFEST == "True") {
       runOnGen3CIWorker = true
     }
     def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(runOnGen3CIWorker)

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -14,11 +14,10 @@ def call(Map config) {
   sleep(30)
   def prLabels = githubHelper.fetchLabels()
 
-  // run all PR checks on jenkins-master by default
-  def theNode = 'master'
+  def runOnGen3CIWorker = false;
   if (prLabels.any{label -> label.name == "run-on-jenkins-ci-worker"}) {
     println('Found [run-on-jenkins-ci-worker] label, running CI on ci worker pod...')
-    theNode = 'gen3-ci-worker'
+    runOnGen3CIWorker = true
   }
   node(theNode) {
     List<String> namespaces = []
@@ -31,7 +30,13 @@ def call(Map config) {
     kubeLocks = []
     testedEnv = "" // for manifest pipeline
     pipeConfig = pipelineHelper.setupConfig(config)
-    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(pipeConfig.MANIFEST, theNode)
+
+    // if this is a Manifests repo, run on separate jenkins worker pod
+    // this is overridable by the 'run-on-jenkins-ci-worker' PR label
+    if (pipeconfigManifest == "True") {
+      runOnGen3CIWorker = true
+    }
+    def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(runOnGen3CIWorker)
     pipelineHelper.cancelPreviousRunningBuilds()
 
     try {


### PR DESCRIPTION
Creating a split pool of CI environments to avoid having jenkins-master being overwhelmed with too many queued up jobs, this will send jobs to the jenkins-ci-worker pod based on the workload around service PRs and Release PRs.