### PR TITLE
chore(nightly-build): Identify which environment is being tested as part of the nightly build.

### DIFF
--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -190,5 +190,7 @@ def manifestDiff(String selectedNamespace) {
 * Returns the hostname of the mutated environment (currently used for nightly-build)
 */
 def fetchHostnameFromMutatedEnvironment() {
-  println('not implemented yet')
+  println('fetching mutatedEnvHostname from nightly.planx-pla.net/manifest.json...')
+  def actualTestedEnv = sh(returnStdout: true, script: "jq -r .global.mutatedEnvHostname < tmpGitClone/nightly.planx-pla.net/manifest.json").trim()
+  println('### ## found this hostname -> ${actualTestedEnv}')
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -192,5 +192,5 @@ def manifestDiff(String selectedNamespace) {
 def fetchHostnameFromMutatedEnvironment() {
   println('fetching mutatedEnvHostname from nightly.planx-pla.net/manifest.json...')
   def actualTestedEnv = sh(returnStdout: true, script: "jq -r .global.mutatedEnvHostname < tmpGitClone/nightly.planx-pla.net/manifest.json").trim()
-  println('### ## found this hostname -> ${actualTestedEnv}')
+  println("### ## found this hostname -> ${actualTestedEnv}")
 }

--- a/vars/manifestHelper.groovy
+++ b/vars/manifestHelper.groovy
@@ -149,6 +149,7 @@ def mergeManifest(String changedDir, String selectedNamespace) {
 def overwriteConfigFolders(String changedDir, String selectedNamespace) {
     List<String> folders = sh(returnStdout: true, script: "ls tmpGitClone/$changedDir").split()
     if (folders.contains('portal')) {
+      println('Copying all the contents from tmpGitClone/$changedDir/portal into cdis-manifest/${selectedNamespace}.planx-pla.net/...')
       sh(script: "cp -rf tmpGitClone/$changedDir/portal cdis-manifest/${selectedNamespace}.planx-pla.net/")
 
       // Some commons display a user agreement quiz after logging in for the
@@ -161,6 +162,7 @@ def overwriteConfigFolders(String changedDir, String selectedNamespace) {
       }
     }
     if (folders.contains('etlMapping.yaml')) {
+      println('Copying etl mapping config from tmpGitClone/$changedDir/etlMapping.yaml into cdis-manifest/${selectedNamespace}.planx-pla.net/...')
       sh(script: "cp -rf tmpGitClone/$changedDir/etlMapping.yaml cdis-manifest/${selectedNamespace}.planx-pla.net/")
     }
   }
@@ -182,4 +184,11 @@ def manifestDiff(String selectedNamespace) {
         return key
       }
     }
-  }
+}
+
+/**
+* Returns the hostname of the mutated environment (currently used for nightly-build)
+*/
+def fetchHostnameFromMutatedEnvironment() {
+  println('not implemented yet')
+}

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -235,10 +235,13 @@ def call(Map config) {
         stage('ModifyManifest') {
          try {
           if(!doNotRunTests) {
+            // this function also calls overwriteConfigFolders
+            testedEnv = manifestHelper.manifestDiff(kubectlNamespace)
+
+            // the nightly build flow will always set testedEnv to nightly.planx-pla.net
+            // unless we fetch the correct name of the mutated environment
             if (isNightlyBuild == "true") {
-              testedEnv = kubeHelper.getHostname(kubectlNamespace)
-            } else {
-              testedEnv = manifestHelper.manifestDiff(kubectlNamespace)
+              testedEnv = manifestHelper.fetchHostnameFromMutatedEnvironment()
             }
 	  } else {
 	    Utils.markStageSkippedForConditional(STAGE_NAME)


### PR DESCRIPTION
We need to know which environment is being tested, but the nightly build `cdis-manifest` folder is always the same.
So there is a new instruction inside this job https://jenkins.planx-pla.net/job/nightly-job-run/ 
```
# Add new special mutatedEnvHostname property to global block to facilitate the definition of testedEnd for testing purposes
jq --argjson obj '{"mutatedEnvHostname": "'"${selectedCommons}"'"}' '.global += $obj' < nightly.planx-pla.net/manifest.json-tmp > temp && mv temp nightly.planx-pla.net/manifest.json-tmp
```
to introduce a new parameter to the manifest's `global` config block.
