### PR TITLE
chore(nightly-build): Add mutatedEnv to nightly-build CI failure slack notification

### DIFF
--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -76,6 +76,7 @@ def soonToBeLegacyRunIntegrationTests(String namespace, String service, String t
 
             if (isNightlyBuild == "true") {
               commaSeparatedListOfLabels += "nightly-run,"
+              failureMsg += ":moon: This nightly-build failed while mutating into *${testedEnv}*... \n"
             }
 
             featureLabelMap.each { testSuite, retryLabel ->


### PR DESCRIPTION
To help the dev-on-call with the nightly build triage, we are adding the name of the environment that has been tested to the Slack notification (CI failure msgs).