### PR TITLE
chore(ci): Add disk volume to ephemeral ci pods

### DIFF
--- a/vars/microservicePipelineK8s.groovy
+++ b/vars/microservicePipelineK8s.groovy
@@ -63,6 +63,13 @@ spec:
         secretKeyRef:
           name: jenkins-g3auto
           key: google_app_creds.json
+    volumeMounts:
+    - mountPath: /home/jenkins/agent
+      name: ci-datadir
+  volumes:
+  - name: ci-datadir
+    persistentVolumeClaim:
+      claimName: datadir-jenkins-ci
   serviceAccount: jenkins-service
   serviceAccountName: jenkins-service
 '''


### PR DESCRIPTION
We need to persist the PR check's workspaces inside a volume in case we need to investigate / reproduce some test failure.

TODO: Figure out how to clean this disk volume periodically. 