### PR TITLE
removed pfbexport test suite from PRC commons

### DIFF
--- a/vars/microservicePipelineK8s.groovy
+++ b/vars/microservicePipelineK8s.groovy
@@ -157,9 +157,11 @@ spec:
                                 selectedTests.add("all")
 
                                 // include long running tests.in the nightly-build
-                                testedEnv = manifestHelper.fetchHostnameFromMutatedEnvironment()
-                                if(isNightlyBuild == "true" && !testedEnv.contains("pandemic")){
-                                    selectedTests.add("suites/portal/pfbExportTest.js")
+                                if(isNightlyBuild == "true"){
+				    testedEnv = manifestHelper.fetchHostnameFromMutatedEnvironment()
+				    if(!testedEnv.contains("pandemic")){	
+                                        selectedTests.add("suites/portal/pfbExportTest.js")
+				    }
                                 }
                             }
                         } catch (ex) {

--- a/vars/microservicePipelineK8s.groovy
+++ b/vars/microservicePipelineK8s.groovy
@@ -157,7 +157,8 @@ spec:
                                 selectedTests.add("all")
 
                                 // include long running tests.in the nightly-build
-                                if (isNightlyBuild == "true") {
+                                testedEnv = manifestHelper.fetchHostnameFromMutatedEnvironment()
+                                if(isNightlyBuild == "true" && !testedEnv.contains("pandemic")){
                                     selectedTests.add("suites/portal/pfbExportTest.js")
                                 }
                             }


### PR DESCRIPTION
removing pfbexport test suite for pandemic response commons in nightly-build

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
