### PR TITLE
(PXP-9867): Archive `**/output/*.log` files

### DIFF
--- a/vars/pipelineHelper.groovy
+++ b/vars/pipelineHelper.groovy
@@ -81,6 +81,7 @@ def handleError(e) {
 */
 def teardown(String buildResult) {
   archiveArtifacts(artifacts: '**/output/*.png', allowEmptyArchive: true)
+  archiveArtifacts(artifacts: '**/output/*.log', allowEmptyArchive: true)
   archiveArtifacts(artifacts: '**/output/*.log.gz', allowEmptyArchive: true)
   archiveArtifacts(artifacts: '*.marker', allowEmptyArchive: true)
   archiveArtifacts(artifacts: '*.log', allowEmptyArchive: true)


### PR DESCRIPTION
Jira Ticket: [PXP-9867](https://ctds-planx.atlassian.net/browse/PXP-9867)

`.avro.log` [file from PFB Export tests](https://github.com/uc-cdis/gen3-qa/blob/268c6dd57757cbb31d4e4d9944ea259e91ac2570/suites/portal/pfbExportTest.js#L405) is not being archived by pipeline.

### Improvements
- Archive `**/output/*.log` files

