### PR TITLE
fix(ci-jobs-on-demand-only): Only schedule ci jobs on ondemand nodes

### DIFF
--- a/vars/microservicePipelineK8s.groovy
+++ b/vars/microservicePipelineK8s.groovy
@@ -37,6 +37,15 @@ metadata:
     app: ephemeral-ci-run
     netnolimit: "yes"
 spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: eks.amazonaws.com/capacityType
+            operator: In
+            values:
+            - ONDEMAND
   containers:
   - name: shell
     image: quay.io/cdis/gen3-ci-worker:master


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes
Only deploy ci jobs on on demand nodes

### Improvements


### Dependency updates


### Deployment changes
