### PR TITLE
Set ephemeral storage resource value

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -73,7 +73,7 @@ spec:
       requests:
         cpu: 1
         memory: 2Gi
-	ephemeral-storage: 2Gi
+        ephemeral-storage: 2Gi
     env:
     - name: AWS_DEFAULT_REGION
       value: us-east-1

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -73,6 +73,7 @@ spec:
       requests:
         cpu: 1
         memory: 2Gi
+	ephemeral-storage: 2Gi
     env:
     - name: AWS_DEFAULT_REGION
       value: us-east-1


### PR DESCRIPTION
to prevent errors like
```
1 Evicted: The node was low on resource: ephemeral-storage. Container shell was using 549232Ki, which exceeds its request of 0. Container jnlp was using 6556Ki, which exceeds its request of 0.
```
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
