### PR TITLE
Fix `git log` command to work with newer versions of `git`

### DIFF
--- a/vars/gitHelper.groovy
+++ b/vars/gitHelper.groovy
@@ -5,7 +5,7 @@
 */
 def setGitEnvVars(String currentRepoName) {
   dir('tmpGitClone') {
-    (gitCommit, gitPreviousCommit) = sh(script: 'git log --author=Jenkins --invert-grep -10 --pretty="format: %h"', returnStdout: true).split('\n')
+    (gitCommit, gitPreviousCommit) = sh(script: 'git log --pretty="format: %h"', returnStdout: true).split('\n')
     println(gitCommit)
     println(gitPreviousCommit)
     env.GIT_COMMIT = gitCommit.trim()

--- a/vars/gitHelper.groovy
+++ b/vars/gitHelper.groovy
@@ -62,7 +62,7 @@ def fetchAllRepos(String currentRepoName) {
     } else {
       git(
         url: 'https://github.com/uc-cdis/cloud-automation.git',
-        branch: 'master'
+        branch: 'fix-sim-py3.9'
       );
     }
   }

--- a/vars/gitHelper.groovy
+++ b/vars/gitHelper.groovy
@@ -25,7 +25,7 @@ def fetchAllRepos(String currentRepoName) {
     } else {
       git(
         url: 'https://github.com/uc-cdis/gen3-qa.git',
-        branch: 'fix-sim-py3.9'
+        branch: 'master'
       );
     }
   }

--- a/vars/gitHelper.groovy
+++ b/vars/gitHelper.groovy
@@ -25,7 +25,7 @@ def fetchAllRepos(String currentRepoName) {
     } else {
       git(
         url: 'https://github.com/uc-cdis/gen3-qa.git',
-        branch: 'master'
+        branch: 'fix-sim-py3.9'
       );
     }
   }

--- a/vars/gitHelper.groovy
+++ b/vars/gitHelper.groovy
@@ -25,7 +25,7 @@ def fetchAllRepos(String currentRepoName) {
     } else {
       git(
         url: 'https://github.com/uc-cdis/gen3-qa.git',
-        branch: 'fix-sim-py3.9'
+        branch: 'master'
       );
     }
   }
@@ -62,7 +62,7 @@ def fetchAllRepos(String currentRepoName) {
     } else {
       git(
         url: 'https://github.com/uc-cdis/cloud-automation.git',
-        branch: 'fix-sim-py3.9'
+        branch: 'master'
       );
     }
   }

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -95,7 +95,7 @@ spec:
         memory: 500Mi
         ephemeral-storage: 500Mi
   - name: shell
-    image: quay.io/cdis/gen3-ci-worker:master
+    image: quay.io/cdis/gen3-ci-worker:fix-sim-py3.9
     imagePullPolicy: Always
     command:
     - sleep

--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -95,7 +95,7 @@ spec:
         memory: 500Mi
         ephemeral-storage: 500Mi
   - name: shell
-    image: quay.io/cdis/gen3-ci-worker:fix-sim-py3.9
+    image: quay.io/cdis/gen3-ci-worker:master
     imagePullPolicy: Always
     command:
     - sleep


### PR DESCRIPTION
Change `git log --author=Jenkins --invert-grep -10 --pretty="format: %h"` to `git log -10 --pretty="format: %h"` because:
- git was updated to a new version in https://github.com/uc-cdis/cloud-automation/pull/2398
- `git log`'s `--invert-grep` now only works with the `--grep` param, not with the `--author` param ([ref](https://stackoverflow.com/questions/6889830/equivalence-of-git-log-exclude-author/70644305#70644305))
- there is no need to exclude commits anymore because we don't push commits with a "Jenkins" user

### Improvements
- Fix `git log` command to work with newer versions of `git`
