### PR TITLE
Save pod logs and send slack messages for k8sRest failures

### DIFF
--- a/vars/microservicePipeline.groovy
+++ b/vars/microservicePipeline.groovy
@@ -411,9 +411,7 @@ spec:
                                 Utils.markStageSkippedForConditional(STAGE_NAME)
                             }
                         } catch (ex) {
-                            // ignore aborted pipelines (not a failure, just some subsequent commit that initiated a new build)
-                            if (ex.getClass().getCanonicalName() != "hudson.AbortException" &&
-                            ex.getClass().getCanonicalName() != "org.jenkinsci.plugins.workflow.steps.FlowInterruptedException") {
+                            if (ex.getClass().getCanonicalName() != "org.jenkinsci.plugins.workflow.steps.FlowInterruptedException") {
                                 metricsHelper.writeMetricWithResult(STAGE_NAME, false)
                                 kubeHelper.sendSlackNotification(kubectlNamespace, isNightlyBuild)
                                 kubeHelper.saveLogs(kubectlNamespace)


### PR DESCRIPTION
Jira Ticket: [GQE-151](https://ctds-planx.atlassian.net/browse/GQE-151)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->
Jenkins is throwing `hudson.AbortException` when the k8sReset times out after the recent version update. And this is preventing slack notifications and pod log archival.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[GQE-151]: https://ctds-planx.atlassian.net/browse/GQE-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ