### PR TITLE
Send nightly failures to dev-oncall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@
 # Super simple example of a Dockerfile, for use in testing Quay Build detection
 # Just here so we can test the 'WaitForQuayBuild' pipeline stage.
 #
-FROM ubuntu:kinetic
+FROM ubuntu:noble

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -108,6 +108,9 @@ def soonToBeLegacyRunIntegrationTests(String namespace, String service, String t
           failureMsg += "\n " + commonMsg
 
           slackSend(color: 'bad', channel: isNightlyBuild == "true" ? "#nightly-builds" : "#gen3-qa-notifications", message: failureMsg)
+          if (isNightlyBuild) {
+            slackSend(color: 'bad', channel: "#gen3-dev-oncall", message: failureMsg)
+          }
           currentBuild.result = 'ABORTED'
           error("aborting build - testsuite failed")
         } else {

--- a/vars/testHelper.groovy
+++ b/vars/testHelper.groovy
@@ -107,10 +107,7 @@ def soonToBeLegacyRunIntegrationTests(String namespace, String service, String t
           }
           failureMsg += "\n " + commonMsg
 
-          slackSend(color: 'bad', channel: isNightlyBuild == "true" ? "#nightly-builds" : "#gen3-qa-notifications", message: failureMsg)
-          if (isNightlyBuild) {
-            slackSend(color: 'bad', channel: "#gen3-dev-oncall", message: failureMsg)
-          }
+          slackSend(color: 'bad', channel: isNightlyBuild == "true" ? "#nightly-builds #gen3-dev-oncall" : "#gen3-qa-notifications", message: failureMsg)
           currentBuild.result = 'ABORTED'
           error("aborting build - testsuite failed")
         } else {


### PR DESCRIPTION


Link to JIRA ticket if there is one: 

### New Features
- Sends nightly failures to dev-oncall 
### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
